### PR TITLE
Enhance HLD docs for dns, directory, and calendar

### DIFF
--- a/calendar/HLD.md
+++ b/calendar/HLD.md
@@ -2,16 +2,82 @@
 
 ## Overview
 
-The `calendar` module provides calendar functionality for displaying events and walks in calendar format.
+The `calendar` module renders month-by-month calendars and injects per-day walk/event details supplied by event/feed modules.
 
-**Purpose**: Calendar display functionality.
+**Purpose**: Calendar display for walks and events.
 
 **Key File**: `calendar/calendar.php`
+
+## Component Diagram
+
+```
+                +-------------------+
+                | REventCalendar    | (event display adapter)
+                +-------------------+
+                          |
+                          v Display(...) passes events + display flags
++-------------------+   show(display, events)   +-------------------+
+| RCalendar         |-------------------------->| REventGroup / feed |
+| (calendar layout) |<------ addEvent() --------+-------------------+
+|                   |      (per day content)
++---------+---------+
+          |
+          v renders HTML
+   Front-end calendar widget (uses ra.js toggle)
+```
+
+## Key Classes / Functions
+
+### `RCalendar`
+- **State**: sizing (`$size`), label formats, current month/year cursors, event provider reference, and whether to display all months.
+- **Responsibilities**: iterate months, build navigation, render day grids, and delegate per-day content to the supplied events object via `addEvent`.
+- **Core Methods**:
+  - `show($display, $events)`: drives month rendering starting from the current month through the last available event date.
+  - `_showDay($cellNumber)`: positions days in the grid, highlights today, and injects event HTML.
+  - `_createNavi($navtype)`: renders Prev/Next controls wired to `ra.html.toggleVisibilities`.
+
+### `REventCalendar` (in `event/calendar.php`)
+- Adapts JSON walks/event data for `RCalendar`.
+- Adds CSS/JS assets (`calendar.css`, `ramblerslibrary.css`, `ra.js`), configures month labels, and invokes `RCalendar->show`.
+
+### `REventGroup::addEvent` (from `event/group.php`)
+- Supplies the `addEvent` interface expected by `RCalendar`, returning HTML for each day (lists, hover blocks, etc.).
+
+## Public Interfaces & Usage
+
+- `new RCalendar(int $size, bool $displayAll)`: set calendar size variant and whether to render all months at once.
+- `setMonthFormat(string $format)`: PHP date format used in month headers (default `Y M`).
+- `show($display, $events): void`: emit calendar HTML using the provided event provider.
+
+Typical usage flows through `REventCalendar`:
+```php
+$adapter = new REventCalendar(250);   // size: 0, 200, 250, or 400
+$adapter->displayAll();               // optional: render all months up to last event
+$adapter->setMonthFormat("F 'y");     // optional custom header format
+$adapter->Display($eventGroup);       // $eventGroup implements addEvent/getLastDate
+```
+The `$eventGroup` is usually built from JSON walks or event feeds.
+
+## Data Flow & Integration Points
+
+- **Inputs**:
+  - Event data from `REventGroup` populated by feeds (`event/feed.php`, `event/group.php`) or JSON walks (`jsonwalks/std`).
+  - Display hints (`$display` string) passed through to `REventGroup::EventList`.
+- **Processing**:
+  - Determine calendar range from the current date to the last event date.
+  - For each day cell, call `$events->addEvent($display, $text, $currentDate)` to render walk/event details.
+  - Navigation links toggle month visibility via `ra.html.toggleVisibilities` in `media/lib_ramblers/js/ra.js`.
+- **Outputs**:
+  - HTML calendar blocks styled by `media/lib_ramblers/calendar/calendar.css` and `ramblerslibrary.css`.
+  - Event content wrapped in interactive toggles/hover blocks provided by the event module.
+- **Integration**:
+  - Calendar pages commonly ingest event feeds (see [`event/HLD.md`](../event/HLD.md)).
+  - JSON walks integrations (see [`jsonwalks/std/HLD.md`](../jsonwalks/std/HLD.md)) can supply the underlying event data structures.
+  - Calendar markup can be embedded in Joomla components/modules alongside leaflet map scripts that register the same walks.
 
 ## References
 
 - See [event HLD](../event/HLD.md) for event aggregation
 - See [jsonwalks/std HLD](../jsonwalks/std/HLD.md) for calendar view in displays
 - `calendar/calendar.php` - Calendar implementation
-
 

--- a/directory/HLD.md
+++ b/directory/HLD.md
@@ -2,14 +2,53 @@
 
 ## Overview
 
-The `directory` module provides directory listing functionality.
+The `directory` module renders simple directory listings, filtering by allowed extensions and decorating entries with optional descriptions.
 
-**Purpose**: Directory listing utilities.
+**Purpose**: Directory listing utilities for front-end rendering within Joomla-powered pages.
 
 **Key File**: `directory/list.php`
+
+## Component Diagram
+
+```
++----------------+    reads          +----------------------+
+| RDirectoryList |------------------>| Filesystem folder    |
+|                |    uses           +----------------------+
+|                |----> JFactory/JText (messages)
+|                |----> JURI::base() (link roots)
++----------------+
+```
+
+## Key Classes / Functions
+
+### `RDirectoryList`
+- **State**: allowed file extensions (`$fileTypes`) and collected filenames.
+- **Responsibilities**: verify folder existence, enumerate files, filter by extension, load optional `.text`/`.txt` description files, and emit HTML `<ul>` listings.
+- **Helper**: `endsWith($haystack, $needle)` to match file extensions.
+
+## Public Interfaces & Usage
+
+- `__construct(array $fileTypes)`: set the extensions to include (e.g., `['.pdf', '.docx']`).
+- `listItems(string $folder, int $sort = self::ASC): void`: echo an HTML unordered list of links sorted ascending or descending. Errors are routed through Joomla messaging (`enqueueMessage`).
+
+**Example**
+```php
+$listing = new RDirectoryList(['.pdf', '.docx']);
+$listing->listItems('media/downloads', RDirectoryList::DESC);
+```
+This produces a `<ul>` of download links rooted at `JURI::base() . 'media/downloads'`, with optional descriptions from `filename.text` or `filename.txt`.
+
+## Data Flow & Integration Points
+
+- **Input**: target folder path and sort order from calling code.
+- **Processing**:
+  - Validate folder existence; surface errors via `JFactory::getApplication()->enqueueMessage`.
+  - Enumerate directory contents (`opendir`/`readdir`), filter by `fileTypes`, and load matching description sidecar files.
+  - Generate link URLs using `JURI::base()` so links honor the site base path.
+- **Output**: HTML written directly (echo) for Joomla templates or module outputs.
+- **Integration**: typically embedded in Joomla components/modules; depends on Joomla globals (`JFactory`, `JText`, `JURI`) and the filesystem. Can be paired with media or document folders where sidecar description files are maintained.
 
 ## References
 
 - `directory/list.php` - Directory listing implementation
-
 

--- a/dns/HLD.md
+++ b/dns/HLD.md
@@ -2,14 +2,50 @@
 
 ## Overview
 
-The `dns` module provides DNS record management functionality.
+The `dns` module resolves mail-related DNS records to help the library discover hosting-specific mail servers for a given domain.
 
-**Purpose**: DNS record management.
+**Purpose**: DNS record discovery for mail routing.
 
 **Key File**: `dns/DnsRecord.php`
+
+## Component Diagram
+
+```
++-------------+       dns_get_record(DNS_ALL)       +---------------------+
+| RDnsRecord  |------------------------------------>| External DNS server |
+|             |<----------- array of records -------+---------------------+
++-------------+
+```
+
+## Key Classes / Functions
+
+### `RDnsRecord`
+- **State**: stores the target domain.
+- **Responsibilities**: invoke PHP’s `dns_get_record` to retrieve DNS data and derive the appropriate SSL mail server hostname.
+- **Core Method**: `getSSLMailServer()` uses the IPv4 address of `mail.<domain>` to construct the `mail<octet>.extendcp.co.uk` host expected by the hosting provider.
+
+## Public Interfaces & Usage
+
+- `__construct(string $domain)`: capture the domain whose mail server should be resolved.
+- `getSSLMailServer(): string`: return the resolved mail host, or an empty string if resolution fails.
+
+**Example**
+```php
+$resolver = new RDnsRecord('ramblers.org.uk');
+$sslHost = $resolver->getSSLMailServer();
+if ($sslHost !== '') {
+    // Use $sslHost to configure IMAP/SMTP endpoints.
+}
+```
+
+## Data Flow & Integration Points
+
+- **Input**: a domain string supplied by calling code.
+- **Processing**: `dns_get_record` queries external DNS, the first result’s `ip` field is parsed to derive the hosting-specific server name.
+- **Output**: hostname string to feed into mail configuration code.
+- **Integration**: consumed wherever the application needs to pre-fill or validate mail server settings (e.g., setup helpers or diagnostics). No direct coupling to other modules beyond PHP DNS functions.
 
 ## References
 
 - `dns/DnsRecord.php` - DNS record class
-
 


### PR DESCRIPTION
## Summary
- expand HLDs for dns, directory, and calendar modules with component diagrams and interface details
- document data flows and integration points for feeds, directory listings, and DNS lookups
- add usage examples and snippets for the public interfaces

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a0e3b3bc8321b1cf439979dcaaa4)