### PR TITLE
Add Walks Manager HLD and update documentation references

### DIFF
--- a/errors/HLD.md
+++ b/errors/HLD.md
@@ -141,9 +141,9 @@ sequenceDiagram
 
 ### Used By
 - **All modules**: Universal error reporting
-- **RJsonwalksWmFeed**: WM API errors → [jsonwalks/wm HLD](../jsonwalks/wm/ARCHITECTURE.md)
+- **RJsonwalksWmFeed**: WM API errors → [jsonwalks/wm HLD](../jsonwalks/wm/HLD.md)
 - **RFeedhelper**: Feed fetch errors → [feedhelper HLD](../feedhelper/HLD.md)
-- **RJsonwalksWmFileio**: File I/O errors → [jsonwalks/wm HLD](../jsonwalks/wm/ARCHITECTURE.md)
+- **RJsonwalksWmFileio**: File I/O errors → [jsonwalks/wm HLD](../jsonwalks/wm/HLD.md)
 - **ROrganisation**: Organisation feed errors → [organisation HLD](../organisation/HLD.md)
 
 ### External Services
@@ -246,7 +246,7 @@ RErrors::notifyError(
 ## References
 
 ### Related HLD Documents
-- [jsonwalks/wm HLD](../jsonwalks/wm/ARCHITECTURE.md) - WM error usage
+- [jsonwalks/wm HLD](../jsonwalks/wm/HLD.md) - WM error usage
 - [feedhelper HLD](../feedhelper/HLD.md) - Feed error usage
 - [organisation HLD](../organisation/HLD.md) - Organisation error usage
 
@@ -255,5 +255,3 @@ RErrors::notifyError(
 
 ### External Services
 - Error Store: `https://errors.theramblers.org.uk/store_errors.php`
-
-

--- a/feedhelper/HLD.md
+++ b/feedhelper/HLD.md
@@ -223,9 +223,8 @@ $feedHelper->clearCache(); // Remove all cached files
 ### Related HLD Documents
 - [errors HLD](../errors/HLD.md) - Error reporting system
 - [organisation HLD](../organisation/HLD.md) - Organisation feed usage
-- [jsonwalks/wm HLD](../jsonwalks/wm/ARCHITECTURE.md) - WM feed system (similar but specialized)
+- [jsonwalks/wm HLD](../jsonwalks/wm/HLD.md) - WM feed system (similar but specialized)
 
 ### Key Source Files
 - `feedhelper/feedhelper.php` - RFeedhelper class
-
 

--- a/jsonwalks/wm/HLD.md
+++ b/jsonwalks/wm/HLD.md
@@ -1,0 +1,108 @@
+# Walks Manager (WM) Feed System - High Level Design
+
+## Overview
+
+The `jsonwalks/wm` module provides the Walks Manager integration layer for Ramblers Library. It builds WM API URLs, retrieves JSON (with retries and gzip support), applies a 10-minute cache window, and hands validated items back to the `jsonwalks` domain for conversion into `RJsonwalksWalk` objects.
+
+**Key Classes (module-owned)**
+- `RJsonwalksWmFeed` – Orchestrates reads from WM API or cache and performs JSON validation.【F:jsonwalks/wm/feed.php†L17-L133】
+- `RJsonwalksWmCachefolder` – Manages cache directory operations (read/write/mtime checks).【F:jsonwalks/wm/cachefolder.php†L14-L65】
+- `RJsonwalksWmFileio` – HTTP/file reader with retry, HTTPS upgrade, gzip, and error redaction.【F:jsonwalks/wm/fileio.php†L9-L69】
+- `RJsonwalksWmFeedoptions` – Builds WM API URLs and deterministic cache filenames.【F:jsonwalks/wm/feedoptions.php†L7-L85】
+- `RJsonwalksWmOrganisation` – Optional source selector based on WM “last updated” timestamps (rarely used in practice).【F:jsonwalks/wm/organisation.php†L13-L113】
+
+**Constants**
+- `WALKMANAGER` – Base WM API URL (`https://walks-manager.ramblers.org.uk/api/volunteers/walksevents?`).【F:jsonwalks/wm/feed.php†L9-L21】
+- `APIKEY` – WM API key (redacted in logs via `RJsonwalksWmFileio::setSecretStrings`).【F:jsonwalks/wm/feed.php†L9-L33】
+- `READSOURCE` – Enum for `FEED` vs `CACHE`.【F:jsonwalks/wm/feed.php†L136-L143】
+
+## Component Architecture
+
+```
+Joomla module/page
+        │
+        ▼
+RJsonwalksFeed → RJsonwalksSourcewalksmanager → RJsonwalksWmFeed
+                                                    │
+                                                    ├─ RJsonwalksWmFeedoptions (URL + cache key)
+                                                    ├─ RJsonwalksWmCachefolder (read/write/mtime)
+                                                    └─ RJsonwalksWmFileio (HTTP/local IO, retries)
+```
+
+## RJsonwalksWmFeed (`feed.php`)
+
+### Public Interface
+
+- `getGroupFutureItems($groups, $readwalks, $readevents, $readwellbeingwalks): array`  
+  Builds a 12-month date window starting “today”, sets inclusion flags, and delegates to `getFeed` for cache/HTTP retrieval.【F:jsonwalks/wm/feed.php†L25-L50】
+
+- `getItemsWithinArea($latitude, $longitude, $distance, $readwalks, $readevents, $readwellbeingwalks): array`  
+  Builds an area query (lat/long/radius) and delegates to `getFeed`. Note: both walk/event inclusion flags are mirrored into `include_events/include_walks` before calling WM.【F:jsonwalks/wm/feed.php†L52-L75】
+
+### Core Behaviour
+
+- **Cache selection**: `whichSource()` returns `CACHE` when a cache file exists and is younger than 10 minutes; otherwise `FEED`. Organisation-based source selection can be toggled by changing `$method`.【F:jsonwalks/wm/feed.php†L85-L118】
+- **Cache fallback**: On feed failure, it will read any existing cache file even if stale; on success it writes the fresh body back to cache.【F:jsonwalks/wm/feed.php†L85-L118】
+- **Validation**: `convertResults()` ensures JSON starts with `{`, decodes, and checks for expected properties before returning `$items->data`; returns `[]` on any failure.【F:jsonwalks/wm/feed.php†L120-L158】
+- **Error reporting**: Errors are routed through `RJsonwalksWmFileio::errorMsg`/`RErrors::notifyError` with API keys redacted.【F:jsonwalks/wm/feed.php†L160-L175】【F:jsonwalks/wm/fileio.php†L9-L69】
+
+## RJsonwalksWmFileio (`fileio.php`)
+
+### Public Interface
+
+- `readFile($urlOrPath)` – Reads HTTP(S) URLs or local files with HTTPS upgrade, gzip support, 3 retry attempts, and an 8s timeout. Returns string or `false`. Secrets registered via `setSecretStrings()` are redacted in errors.【F:jsonwalks/wm/fileio.php†L9-L69】
+- `writeFile($filename, $data)` – Thin wrapper over Joomla file write (used by cache).【F:jsonwalks/wm/fileio.php†L49-L57】
+- `setSecretStrings(array $values)` – Registers secrets to mask in logs.【F:jsonwalks/wm/fileio.php†L13-L17】
+
+### Error Handling
+
+Errors are reported through `RErrors::notifyError` with sensitive substrings removed; no exceptions are thrown (callers see `false`).【F:jsonwalks/wm/fileio.php†L28-L44】
+
+## RJsonwalksWmCachefolder (`cachefolder.php`)
+
+### Responsibilities
+
+- Ensures the cache directory exists under `JPATH_SITE/cache/<name>`.【F:jsonwalks/wm/cachefolder.php†L14-L28】
+- Provides `fileExists`, `readFile`, `writeFile`, and `lastModified` helpers for cache management.【F:jsonwalks/wm/cachefolder.php†L28-L65】
+- Used by `RJsonwalksWmFeed` to decide freshness and to persist successful feed reads.
+
+## RJsonwalksWmFeedoptions (`feedoptions.php`)
+
+### Responsibilities
+
+- Holds query parameters (group codes, date range, inclusion flags, area search).【F:jsonwalks/wm/feedoptions.php†L7-L57】
+- Builds the WM API URL via `getFeedURL()` (uses `http_build_query`) and constructs deterministic cache filenames via `getCacheFileName($extension)`.【F:jsonwalks/wm/feedoptions.php†L57-L85】
+
+### Key Properties
+
+`groupCode`, `include_walks`, `include_events`, `include_wellbeing_walks`, `latitude`, `longitude`, `distance`, `date_start`, `date_end`.【F:jsonwalks/wm/feedoptions.php†L7-L57】
+
+## RJsonwalksWmOrganisation (`organisation.php`)
+
+### Role
+
+Optional helper that can choose FEED vs CACHE based on WM group “last updated” timestamps. It is wired into `RJsonwalksWmFeed` but bypassed when `$method === "time"` (the default).【F:jsonwalks/wm/feed.php†L81-L91】【F:jsonwalks/wm/organisation.php†L13-L113】
+
+## Data Flow (time-based mode)
+
+```
+RJsonwalksFeedoptions → RJsonwalksSourcewalksmanager → RJsonwalksWmFeed
+   → RJsonwalksWmFeedoptions (URL + cache key)
+   → whichSource(): cache? (<10 min) → read cache
+                    else → RJsonwalksWmFileio::readFile(feed URL)
+   → on success: cache write
+   → convertResults(): decode/validate → items->data
+   → returned to Source → converted to RJsonwalksWalk → presenters
+```
+
+## Error Handling Philosophy
+
+- Graceful degradation: return `[]` on failure; never throw.
+- Redacted logging: API keys are masked in error output.
+- Cache-first resilience: stale cache is used when WM API is unavailable.
+
+## Testing/Mocking Hooks
+
+- Mock `RJsonwalksWmFileio::readFile()` to simulate API responses/timeouts.
+- Inject test cache files and vary mtimes to exercise `whichSource()`.
+- Verify redaction by registering dummy secrets via `setSecretStrings()`.

--- a/leaflet/HLD.md
+++ b/leaflet/HLD.md
@@ -194,6 +194,11 @@ public $licenseKeys; // stdClass with API keys
 - **Location**: `leaflet/gpx/map.php`, `maplist.php`
 - **See**: [leaflet/gpx HLD](gpx/HLD.md)
 
+#### RLeafletGpxMaplist (folder-driven GPX index)
+- **Purpose**: Enumerate a GPX folder, cache a JSON summary, and present the list/map with downloads, elevation, and pagination.
+- **Flow**: `display()` builds a stats object from the configured folder, sorts items (title or date), sets command `ra.display.gpxFolder`, and loads `maplist.js`, tabs, and cvList assets for the client grid + map combo.【F:leaflet/gpx/maplist.php†L24-L83】
+- **Caching**: `RGpxStatistics` regenerates `0000gpx_statistics_file.json` only when the most recently modified file is not that JSON (i.e., the folder contents changed), otherwise it reuses the cached JSON for quick responses.【F:gpx/statistics.php†L16-L55】 A rebuild scans `.gpx` files, extracts meta (optionally from GPX itself), and logs diagnostics until Joomla cache expiry.【F:gpx/statistics.php†L57-L130】
+
 #### RLeafletJsonList
 - **Purpose**: Display map markers from JSON data
 - **Location**: `leaflet/json/list.php`
@@ -330,6 +335,10 @@ flowchart LR
 - **Purpose**: Route plotting functionality
 - **Dependencies**: Leaflet.js, routing libraries
 - **Integration**: Loaded for routing features
+
+##### Plot Route workflow (server ↔ client)
+- **Server**: `RLeafletMapdraw` sets the command `ra.display.plotRoute`, enables drawing-friendly options (fullscreen, fitbounds, elevation, right-click, print), and enqueues draw/upload/download/smart-route controls plus styles.【F:leaflet/mapdraw.php†L21-L54】
+- **Client**: `ra.display.plotRoute` bootstraps `ra.leafletmap`, wires Leaflet.draw with custom labels, and attaches GPX upload/download, reverse, simplify, and smart-route controls (optional ORS key). All drawn layers land in a FeatureGroup and trigger elevation refreshes and styling updates on edits.【F:media/leaflet/ra.display.plotRoute.js†L8-L188】
 
 #### `media/leaflet/ra-display-places.js`
 - **Purpose**: Place management and display

--- a/leaflet/gpx/HLD.md
+++ b/leaflet/gpx/HLD.md
@@ -6,9 +6,13 @@ The `leaflet/gpx` module provides GPX route file display on Leaflet maps with el
 
 **Purpose**: GPX route visualization with elevation profiles.
 
-**Key Classes**: 
+**Key Classes (this component)**: 
 - `RLeafletGpxMap` extends `RLeafletMap`
-- `RLeafletGpxMaplist` (if exists)
+- `RLeafletGpxMaplist` extends `RLeafletMap` (folder-driven GPX list + map)
+
+**Dependencies (supporting utilities/assets treated as part of the Leaflet stack)**:
+- `RGpxStatistics` / `RGpxJsonlog` / `RGpxFile` / `RGpxStatistic` for folder scanning, caching, and per-file parsing.【F:gpx/statistics.php†L16-L130】
+- Client assets under `media/leaflet/*` (e.g., `gpx/maplist.js`, elevation, draw/upload/download controls) are documented here as part of the Leaflet module’s media surface.
 
 ## Public Interface
 
@@ -21,16 +25,46 @@ public $imperial = false;
 public $addDownloadLink = "Users";
 ```
 
+**Behaviour**: Validates that the supplied file exists and has a `.gpx` extension, sets `gpxfile` and presentation flags on the data object, and configures the map command to `ra.display.gpxSingle` so the client loads the route with elevation. Downloads are exposed when the file is present; invalid input is surfaced via Joomla messages.【F:leaflet/gpx/map.php†L15-L78】
+
+### RLeafletGpxMaplist (folder index)
+
+```php
+public $folder = "images";
+public $addDownloadLink = "Users"; // None|Users|Public
+public $descriptions = true;
+public $getMetaFromGPX = true;
+public $displayAsPreviousWalks = false;
+public $displayTitle = true;
+public $linecolour = "#782327";
+public $imperial = false;
+
+public function display();
+```
+
+**Behaviour**:
+- Builds a folder summary via `RGpxStatistics`, which regenerates `0000gpx_statistics_file.json` when any file newer than the JSON exists; otherwise it reuses the cached JSON for fast loads.【F:leaflet/gpx/maplist.php†L24-L83】【F:gpx/statistics.php†L16-L55】
+- Sorting: by title (default) or by date when `displayAsPreviousWalks` is true.【F:leaflet/gpx/maplist.php†L32-L65】
+- Map options: clustering, elevation, fullscreen, mouseposition, rightclick, fitbounds, print, settings, and mylocation are enabled to support list + map views.【F:leaflet/gpx/maplist.php†L42-L53】
+- Command: publishes `ra.display.gpxFolder` with a data object containing items, download state (0/1/2), folder name, line colour, and presentation flags for the client to render markers, elevation, pagination, and downloads.【F:leaflet/gpx/maplist.php†L67-L83】
+- Assets: enqueues `maplist.js`, tabs, cvList, and shared ramblerslibrary styles to deliver the tabbed table/map UI.【F:leaflet/gpx/maplist.php†L75-L82】
+
+### Supporting classes
+- **RGpxStatistics**: Scans the configured folder, extracts metadata from each `.gpx` file (and optional `.txt` descriptions), and writes `0000gpx_statistics_file.json` via `RGpxJsonlog`; emits diagnostics during regeneration to aid admins.【F:gpx/statistics.php†L16-L130】
+- **RGpxFile / RGpxStatistic**: Parse GPX contents to compute title/description (with optional GPX metadata), author/date, start/end coordinates, distance, elevation stats, tracks/segments/routes counts, and duration used in the JSON summary.【F:gpx/statistics.php†L79-L130】
+
 ## Media Dependencies
 
-- `media/leaflet/gpx/maplist.js` - GPX map list functionality
-- `media/vendors/leaflet-gpx-1.3.1/gpx.js` - GPX parsing
+- `media/leaflet/gpx/maplist.js` - GPX folder display (list + map + elevation)
+- `media/leaflet/ra.display.plotRoute.js` - Shared plotting helpers for interactive drawing (loaded by mapdraw, not maplist)
+- `media/vendors/leaflet-gpx-1.3.1/gpx.js` - GPX parsing for single-route display
 - `media/vendors/Leaflet.Elevation-0.0.4-ra/` - Elevation charts
+- `media/lib_ramblers/vendors/cvList/cvList.js|css` - Pagination for folder list/table
+- `media/lib_ramblers/js/ra.tabs.js` - Tabbed UI for list/map toggle
 
 ## References
 
 - [leaflet HLD](../HLD.md) - Main map system
 - `leaflet/gpx/map.php` - RLeafletGpxMap class
 - `leaflet/gpx/maplist.php` - RLeafletGpxMaplist class (if exists)
-
-
+- `gpx/statistics.php` - Folder scanning + JSON caching


### PR DESCRIPTION
## Summary
- add a new jsonwalks/wm/HLD.md covering WM feed, cache, file I/O, options, and organisation selector
- update architecture, errors, and feedhelper docs to point to the new WM HLD path

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a76a0b288321bb3aa7cf6254020b)