### PR TITLE
Standardize HLD integrations across core modules

### DIFF
--- a/accounts/HLD.md
+++ b/accounts/HLD.md
@@ -157,7 +157,12 @@ sequenceDiagram
 - **RHtml**: HTML table formatting → [html HLD](../html/HLD.md)
 - **RSqlUtils**: Table existence checks → [sql HLD](../sql/HLD.md)
 
-## Media Dependencies
+### Key Features (`RAccounts`)
+- Loads hosted site accounts, enriches them with organisation data, and exposes table/log displays.
+- Configures Leaflet map commands/data for `ra.display.accountsMap` with minimal caller setup.
+- Supports multiple display formats and integrates log file analysis for each account.
+
+## Media Integration
 
 ### Server-to-Client Asset Relationship
 
@@ -166,8 +171,8 @@ flowchart LR
     Accounts[RAccounts::addMapMarkers]
     Map[RLeafletMap]
     Loader[RLoad]
-    BaseJS[media/js<br/>ra.js<br/>ra.map.js<br/>ra.tabs.js]
-    AccountsJS[media/accounts/accounts.js]
+    BaseJS[/media/js<br/>ra.js, ra.map.js, ra.tabs.js]
+    AccountsJS[/media/accounts/accounts.js]
     Leaflet[Leaflet core + plugins]
 
     Accounts --> Map
@@ -177,28 +182,17 @@ flowchart LR
     Loader --> AccountsJS
 ```
 
-`RAccounts::addMapMarkers()` invokes `RLoad` to enqueue the shared `media/js` foundation plus `media/accounts/accounts.js`, then defers to `RLeafletMap::display()`/`RLeafletScript::add()` for Leaflet setup before running the `ra.display.accountsMap` client initializer.
+`RAccounts::addMapMarkers()` enqueues `/media/accounts/accounts.js` alongside the shared `/media/js` bootstrap by calling `RLoad::addScript()`; `RLeafletScript::add()` then injects Leaflet core and plugins so that `ra.display.accountsMap` can run in the browser.
 
-### JavaScript File
+### Media Asset Loading
+- **JavaScript entry point**: `/media/accounts/accounts.js` (initialized via `ra.display.accountsMap`).
+- **Server-to-client flow**: `RAccounts::addMapMarkers()` sets the command/data on `RLeafletMap`, uses `RLoad` for the `/media` assets, and delegates to `RLeafletMap::display()` to emit the bootstrapper and data payload.
 
-#### `media/accounts/accounts.js`
-- **Purpose**: Client-side accounts map display
-- **Dependencies**: `ra.js`, `ra.leafletmap.js`, Leaflet.js
-- **Integration**: Loaded via `RLoad::addScript()` in `addMapMarkers()`
-- **Key Functions**:
-  - `ra.display.accountsMap(options, data)` - Main initialization
-  - `this.addMarkers(websites)` - Add hosted site markers
-  - `this.addMarker(item)` - Add individual marker
-  - Marker styling based on account status
-  - Popup content with account details
-- **API**:
-  - `this.lmap` - Leaflet map instance
-  - `this.cluster` - Marker clustering
-  - `this.data` - Hosted site data
-  - `this.load()` - Initialize map and markers
-- **Usage**: Automatically initialized when `RLeafletMap` sets command to `"ra.display.accountsMap"`
-
-**Loading**: `addMapMarkers()` calls `RLoad::addScript()` for `media/js/ra.js`, `media/js/ra.map.js`, `media/js/ra.tabs.js`, and `media/accounts/accounts.js` before invoking `RLeafletMap::display()`.
+### Key Features (`accounts.js`)
+- Status-aware marker clustering and popups for hosted sites.
+- Area vs group iconography based on account code length.
+- Automatic fit-to-bounds after marker creation.
+- Consumes JSON injected by `RAccounts::addMapMarkers()` without extra configuration.
 
 ## Examples
 

--- a/accounts/HLD.md
+++ b/accounts/HLD.md
@@ -148,23 +148,31 @@ sequenceDiagram
 
 ## Integration Points
 
+### Used By
+- **Joomla pages/modules** that list hosted sites or render the hosted sites map → [media/accounts HLD](../media/accounts/HLD.md#integration-points).
+
+### Uses
+- **ROrganisation** for enriching account rows with area/group metadata → [organisation HLD](../organisation/HLD.md#integration-points).
+- **RLeafletMap / RLeafletScript** for map rendering and JSON injection → [leaflet HLD](../leaflet/HLD.md#integration-points).
+- **RLoad** for enqueueing `/media/js` and `/media/accounts/accounts.js` → [media/js HLD](../media/js/HLD.md#integration-points).
+- **RSqlUtils** for existence checks on the accounts table → [sql HLD](../sql/HLD.md#integration-points).
+- **RHtml** for tabular rendering paths → [html HLD](../html/HLD.md#integration-points).
+
 ### Data Sources
-- **Joomla Database**: Account table (`#__ra_accounts_domains`)
-- **ROrganisation**: Organisation data for updates → [organisation HLD](../organisation/HLD.md)
+- **Joomla Database**: `#__ra_accounts_domains` table holding hosted site metadata.
+- **Organisation feed cache**: Group/area codes consumed through `ROrganisation`.
 
 ### Display Layer
-- **RLeafletMap**: Map rendering → [leaflet HLD](../leaflet/HLD.md)
-- **RHtml**: HTML table formatting → [html HLD](../html/HLD.md)
-- **RSqlUtils**: Table existence checks → [sql HLD](../sql/HLD.md)
+- **Server**: `RAccounts::listLogDetails()` (tables) and `RAccounts::addMapMarkers()` (map) prepare payloads.
+- **Client**: `ra.display.accountsMap` in `/media/accounts/accounts.js` renders markers/popups.
 
-### Key Features (`RAccounts`)
-- Loads hosted site accounts, enriches them with organisation data, and exposes table/log displays.
-- Configures Leaflet map commands/data for `ra.display.accountsMap` with minimal caller setup.
-- Supports multiple display formats and integrates log file analysis for each account.
+### Joomla Integration
+- **Document pipeline**: `RLoad::addScript()` and `RLeafletMap::display()` publish cache-busted assets and the bootstrap JSON/command for the browser.
 
-## Media Integration
+### Vendor Library Integration
+- **Leaflet.js + markercluster**: Loaded via `RLeafletScript` for map rendering.
 
-### Server-to-Client Asset Relationship
+### Media Asset Relationships (Server → Client)
 
 ```mermaid
 flowchart LR
@@ -183,10 +191,6 @@ flowchart LR
 ```
 
 `RAccounts::addMapMarkers()` enqueues `/media/accounts/accounts.js` alongside the shared `/media/js` bootstrap by calling `RLoad::addScript()`; `RLeafletScript::add()` then injects Leaflet core and plugins so that `ra.display.accountsMap` can run in the browser.
-
-### Media Asset Loading
-- **JavaScript entry point**: `/media/accounts/accounts.js` (initialized via `ra.display.accountsMap`).
-- **Server-to-client flow**: `RAccounts::addMapMarkers()` sets the command/data on `RLeafletMap`, uses `RLoad` for the `/media` assets, and delegates to `RLeafletMap::display()` to emit the bootstrapper and data payload.
 
 ### Key Features (`accounts.js`)
 - Status-aware marker clustering and popups for hosted sites.
@@ -228,7 +232,7 @@ $accounts = new RAccounts();
 $accounts->updateAccounts();
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Database Operations
 - **Table Checks**: Uses `RSqlUtils::tableExists()` before operations
@@ -242,11 +246,11 @@ $accounts->updateAccounts();
 ## Error Handling
 
 ### Database Errors
-- **Missing Table**: Checked via `RSqlUtils::tableExists()`
-- **Query Failures**: Handled by Joomla database layer
+- **Missing Table**: Checked via `RSqlUtils::tableExists()` before writes.
+- **Query Failures**: Relies on Joomla database error propagation and messages.
 
 ### Organisation Errors
-- **Missing Data**: Shows error message, update skipped
+- **Missing Data**: Shows error message and skips updates rather than failing the batch.
 
 ## References
 

--- a/errors/HLD.md
+++ b/errors/HLD.md
@@ -140,28 +140,30 @@ sequenceDiagram
 ## Integration Points
 
 ### Used By
-- **All modules**: Universal error reporting
-- **RJsonwalksWmFeed**: WM API errors → [jsonwalks/wm HLD](../jsonwalks/wm/HLD.md)
-- **RFeedhelper**: Feed fetch errors → [feedhelper HLD](../feedhelper/HLD.md)
-- **RJsonwalksWmFileio**: File I/O errors → [jsonwalks/wm HLD](../jsonwalks/wm/HLD.md)
-- **ROrganisation**: Organisation feed errors → [organisation HLD](../organisation/HLD.md)
+- **All modules**: Universal error reporting hook.
+- **RJsonwalksWmFeed / RJsonwalksWmFileio** for WM API and cache errors → [jsonwalks/wm HLD](../jsonwalks/wm/HLD.md#integration-points).
+- **RFeedhelper** for HTTP/caching issues → [feedhelper HLD](../feedhelper/HLD.md#integration-points).
+- **ROrganisation** for organisation feed failures → [organisation HLD](../organisation/HLD.md#integration-points).
 
-### External Services
-- **Remote Error Store**: `https://errors.theramblers.org.uk/store_errors.php`
-  - Receives error data via POST
-  - Stores errors for analysis
-  - Returns HTTP 200 on success
+### Uses
+- **cURL** for POSTing structured error payloads to the remote store.
+- **Joomla Application/URI** via `JFactory::getApplication()` and `Uri::getInstance()` for messaging and domain capture.
+- **Joomla Mailer** for optional email notifications.
+
+### Data Sources
+- **Error context** built from inputs (`$errorText`, `$action`, `$level`, `$returncode`), domain, and stack trace.
+
+### Display Layer
+- **Server-side messages**: `enqueueMessage()` renders feedback in Joomla pages; no client JS.
 
 ### Joomla Integration
-- **Joomla Application**: `JFactory::getApplication()`
-  - `enqueueMessage()` for user notifications
-- **Joomla URI**: `Uri::getInstance()` for domain capture
+- **Configuration**: Reads mail-from address from Joomla config; surfaces messages through the Joomla message queue.
 
-## Media Dependencies
+### Vendor Library Integration
+- None beyond PHP cURL and Joomla’s mailer.
 
-### No Media Files
-
-The errors module is server-side only with no JavaScript or CSS dependencies.
+### Media Asset Relationships
+- None; the module is server-side only.
 
 ## Examples
 
@@ -212,12 +214,12 @@ RErrors::notifyError(
 );
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Error Reporting Performance
-- **Remote Store**: cURL POST with 10s connect timeout, 20s total timeout
-- **Non-Blocking**: Errors don't block execution (async reporting)
-- **Stack Traces**: Limited to 5 levels for performance
+- **Remote Store**: cURL POST with 10s connect timeout, 20s total timeout.
+- **Non-Blocking**: Errors don't block execution (async-style reporting).
+- **Stack Traces**: Limited to 5 levels for performance.
 
 ### Optimization Opportunities
 1. **Async Reporting**: Queue errors for background processing
@@ -228,20 +230,20 @@ RErrors::notifyError(
 ## Error Handling
 
 ### Remote Store Failures
-- **cURL Errors**: Logged as Joomla warning message
-- **HTTP Errors**: Non-200 status codes logged
-- **Graceful Degradation**: User message still displayed even if remote store fails
+- **cURL Errors**: Logged as Joomla warning message.
+- **HTTP Errors**: Non-200 status codes logged.
+- **Graceful Degradation**: User message still displayed even if remote store fails.
 
 ### Error Levels
-- **message**: Informational
-- **notice**: Important information
-- **warning**: Potential issues
-- **error**: Critical errors
+- **message**: Informational.
+- **notice**: Important information.
+- **warning**: Potential issues.
+- **error**: Critical errors.
 
 ### Stack Trace Capture
-- **Depth**: 5 levels (configurable via `DEBUG_BACKTRACE_IGNORE_ARGS`)
-- **No Arguments**: Arguments excluded for privacy/performance
-- **JSON Encoded**: Stack trace sent as JSON string
+- **Depth**: 5 levels (configurable via `DEBUG_BACKTRACE_IGNORE_ARGS`).
+- **No Arguments**: Arguments excluded for privacy/performance.
+- **JSON Encoded**: Stack trace sent as JSON string.
 
 ## References
 

--- a/gpx/HLD.md
+++ b/gpx/HLD.md
@@ -6,21 +6,142 @@ The `gpx` module provides GPX file processing utilities including file reading, 
 
 **Purpose**: GPX file processing and statistics.
 
-**Key Files**:
-- `gpx/file.php` - GPX file handling
-- `gpx/jsonlog.php` - JSON log conversion
-- `gpx/statistic.php` - Statistics calculation
-- `gpx/statistics.php` - Statistics aggregation
+**Key Responsibilities**:
+- Parse individual GPX files into structured PHP objects.
+- Calculate per-file statistics (distance, elevation, dates, author, links).
+- Aggregate folder-level statistics and persist them as JSON for reuse.
+- Validate folder contents and emit diagnostics when regenerating caches.
+
+## Component Architecture
+
+```mermaid
+flowchart TB
+    subgraph Parsing["Per-file Parsing"]
+        File[RGpxFile<br/>GPX reader]
+    end
+
+    subgraph Stats["Statistics"]
+        Stat[RGpxStatistic<br/>Value object]
+        Stats[RGpxStatistics<br/>Folder aggregator]
+    end
+
+    subgraph Persistence["Persistence"]
+        Jsonlog[RGpxJsonlog<br/>JSON writer]
+        Cache[0000gpx_statistics_file.json<br/>Cache file]
+    end
+
+    Filesystem[(GPX folder)]
+
+    Filesystem --> File
+    File --> Stat
+    Stat --> Stats
+    Stats --> Jsonlog
+    Jsonlog --> Cache
+```
+
+## Public Interface
+
+### RGpxFile
+- **Responsibility**: Parse an individual GPX file to expose metadata (title, description, author, date, links, start/end coordinates, distance, elevation, tracks/routes, duration).
+- **Key Methods**: Constructor reads the file; public properties expose parsed values.
+
+### RGpxStatistic
+- **Responsibility**: Lightweight value object used to store derived statistics per GPX file (filename, title, description, coordinates, distance, elevation gain, min/max altitude, tracks/routes/duration).
+
+### RGpxJsonlog
+- **Constructor**: `__construct(string $path)`
+- **Methods**:
+  - `addItem(string $id, RGpxStatistic $stat)`: append a stat record keyed by ID.
+  - `writeFile()`: persist the aggregated stats as JSON to disk.
+
+### RGpxStatistics
+- **Constructor**: `__construct(string $folder, bool $getMetaFromGPX)`
+  - Creates/refreshes `0000gpx_statistics_file.json` when newer GPX files are present.
+- **Public Methods**:
+  - `getJson(): string` – return the cached JSON payload for downstream consumers.
+
+### Helper Methods (RGpxStatistics)
+- `processFolder()`: scan the folder, parse GPX files, and add statistics to the JSON log.
+- `processGPXFile(string $file): RGpxStatistic`: parse a single GPX file and build its statistic record.
+- `latestFile(): string`: find the most recently modified file to decide whether to regenerate the cache.
+- `getTitlefromName()` / `getDescription()`: derive defaults when GPX metadata is absent.
+
+## Data Flow
+
+### Folder Scan and Cache Generation
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Caller
+    participant Stats as RGpxStatistics
+    participant FS as Filesystem
+    participant Parser as RGpxFile
+    participant Json as RGpxJsonlog
+
+    Caller->>Stats: new(folder, getMetaFromGPX)
+    Stats->>FS: latestFile()
+    alt Cache stale or missing
+        Stats->>Json: new(JSONFILE)
+        Stats->>FS: processFolder()
+        loop for each .gpx file
+            Stats->>Parser: new RGpxFile(path)
+            Parser-->>Stats: metadata + tracks/routes
+            Stats->>Stats: build RGpxStatistic
+            Stats->>Json: addItem(id, stat)
+        end
+        Stats->>Json: writeFile()
+    end
+    Caller->>Stats: getJson()
+    Stats-->>Caller: JSON string
+```
 
 ## Integration Points
 
-- **leaflet/gpx**: GPX map display → [leaflet/gpx HLD](../leaflet/gpx/HLD.md)
+### Used By
+- **RLeafletGpxMaplist / RLeafletGpxMap** to supply GPX summaries and download metadata → [leaflet/gpx HLD](../leaflet/gpx/HLD.md#integration-points).
+- **RLeafletScript** consumers that need cached GPX statistics for client rendering → [leaflet HLD](../leaflet/HLD.md#integration-points).
+
+### Uses
+- **Filesystem**: Reads `.gpx` files and writes the `0000gpx_statistics_file.json` cache.
+- **RHtml**: Generates diagnostic tables during cache regeneration → [html HLD](../html/HLD.md#integration-points).
+- **Joomla application messaging** for folder errors (`enqueueMessage`).
+
+### Data Sources
+- **Local GPX folders** supplied by callers; optional GPX metadata (title/description) is used when `getMetaFromGPX` is true.
+
+### Display Layer
+- **Server**: Exposes cached JSON via `RGpxStatistics::getJson()` for PHP presenters.
+- **Client**: Map/list presenters in `/media/leaflet/gpx` consume the JSON to render tracks, markers, and download links → [media/leaflet HLD](../media/leaflet/HLD.md#integration-points).
+
+### Joomla Integration
+- **Diagnostics**: Writes HTML diagnostics to the response while rebuilding the cache (until Joomla cache expiry).
+- **Messaging**: Surfaces folder access errors through `JFactory::getApplication()->enqueueMessage`.
+
+### Vendor Library Integration
+- None directly; downstream Leaflet presenters pull in Leaflet/Elevation vendors.
+
+### Media Asset Relationships
+- **Server → Client**: GPX stats JSON produced here is loaded by Leaflet GPX presenters, which then enqueue `/media/leaflet/gpx` JavaScript plus Leaflet/Elevation assets (see [leaflet/gpx HLD](../leaflet/gpx/HLD.md#media-asset-relationships)).
+
+## Performance Observations
+
+- **Cache reuse**: Regenerates statistics only when a GPX file is newer than `0000gpx_statistics_file.json`, keeping repeated requests fast.
+- **Parsing cost**: Per-file parsing is linear in GPX size; folder scans can be noisy but are limited to cache refresh events.
+- **Memory**: Holds stats for all files in memory during regeneration; typical folders remain manageable.
+
+## Error Handling
+
+- **Missing folder**: Emits Joomla error message and stops processing.
+- **Folder access errors**: Logs warnings and continues with an empty file list.
+- **GPX parsing gaps**: Falls back to filename-derived title/description when metadata is absent.
+- **Invalid cache writes**: `writeFile()` failure would leave stale cache; diagnostics are printed during regeneration for visibility.
 
 ## References
 
-- `gpx/file.php` - GPX file class
-- `gpx/jsonlog.php` - JSON log class
-- `gpx/statistic.php` - Statistics class
-- `gpx/statistics.php` - Statistics aggregation
-
+- [leaflet/gpx HLD](../leaflet/gpx/HLD.md) - GPX presentation layer
+- `gpx/file.php` - GPX file parser
+- `gpx/jsonlog.php` - JSON writer
+- `gpx/statistic.php` - Statistic value object
+- `gpx/statistics.php` - Folder aggregation and cache logic
 

--- a/gpxsymbols/HLD.md
+++ b/gpxsymbols/HLD.md
@@ -2,24 +2,113 @@
 
 ## Overview
 
-The `gpxsymbols` module provides GPX symbol display functionality with image assets for letters, numbers, and transport symbols.
+The `gpxsymbols` module renders available GPX waypoint symbols within Joomla views. It discovers symbol assets on disk, streams them to the browser, and wires the companion `/media/gpxsymbols` helper for existence checks.
 
-**Purpose**: GPX symbol rendering and display.
+**Purpose**: GPX symbol rendering and discovery.
 
 **Key File**: `gpxsymbols/display.php`
 
-## Media Dependencies
+## Component Architecture
 
-- `media/gpxsymbols/display.css` - Symbol stylesheet
-- `media/gpxsymbols/letter/*.png` - Letter symbols (26 files)
-- `media/gpxsymbols/number/*.png` - Number symbols (101 files)
-- `media/gpxsymbols/number_white/*.png` - White number symbols (101 files)
-- `media/gpxsymbols/office/*.png` - Office symbols (74 files)
-- `media/gpxsymbols/transport/*.png` - Transport symbols (101 files)
-- `media/gpxsymbols/exists.php` - Symbol existence check
+```mermaid
+flowchart TB
+    subgraph Server[Server-Side]
+        Display[RGpxsymbolsDisplay<br/>display.php]
+        Exists[media/gpxsymbols/exists.php<br/>Asset check]
+    end
 
-## References
+    subgraph Assets[Symbol Assets (/media/gpxsymbols)]
+        CSS[display.css<br/>Styles]
+        Symbols[letter/, number/, office/, transport/]
+    end
 
-- `gpxsymbols/display.php` - Symbol display class
+    subgraph Client[Client Browser]
+        Html[Symbol grid HTML]
+        Images[Loaded symbol images]
+    end
 
+    Display --> Exists
+    Display --> CSS
+    Display --> Html
+    Html --> Images
+    Exists --> Client
+```
 
+## Public Interface
+
+### RGpxsymbolsDisplay
+
+**Main symbol renderer.**
+
+#### Constructor
+```php
+public function __construct()
+```
+- **Behavior**: Obtains the Joomla document and enqueues `/media/lib_ramblers/gpxsymbols/display.css` to style the rendered grid.
+
+#### Symbol Listing Method
+```php
+public function listFolder($folder)
+```
+- **Parameters**: `$folder` - Absolute path to a symbol directory under `/media/lib_ramblers/gpxsymbols/*`.
+- **Behavior**:
+  - Enumerates files, sorts naturally, and renders a `<details>` panel with thumbnails and filenames.
+  - Uses `displayImage()` to emit individual symbol entries.
+
+#### Private Helper
+```php
+private function displayImage($folder, $entry)
+```
+- **Behavior**: Outputs an `<img>` element for the symbol and a caption derived from the filename.
+
+### Key Features
+- Automatic stylesheet injection for symbol grids.
+- Natural sorting of symbol filenames for predictable display order.
+- Reusable renderer that targets any `/media/lib_ramblers/gpxsymbols/*` subfolder.
+
+## Data Flow
+
+### Symbol Discovery Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller as Caller
+    participant Display as RGpxsymbolsDisplay
+    participant Doc as Joomla Document
+    participant FS as File System
+    participant Browser as Browser
+
+    Caller->>Display: new()
+    Display->>Doc: addStyleSheet(/media/lib_ramblers/gpxsymbols/display.css)
+    Caller->>Display: listFolder(media/.../gpxsymbols/letter)
+    Display->>FS: opendir()/readdir()
+    FS-->>Display: filenames
+    loop each symbol
+        Display->>Browser: <img src=".../symbol.png">
+    end
+```
+
+## Integration Points
+
+### Uses
+- **Joomla Document**: Queues `/media/gpxsymbols` assets for the rendered page.
+- **`media/gpxsymbols/exists.php`**: Optional existence checks for symbol files → [media/gpxsymbols HLD](../media/gpxsymbols/HLD.md)
+
+### Media Assets (/media/gpxsymbols)
+- **Server-to-Client Loading**: `RGpxsymbolsDisplay::__construct()` injects the symbol stylesheet via the Joomla document API; the rendered HTML references symbol image files directly under `/media/lib_ramblers/gpxsymbols/*` when building the grid.
+- **Asset Relationship**:
+
+```mermaid
+flowchart LR
+    Display[RGpxsymbolsDisplay]
+    Loader[JDocument::addStyleSheet]
+    Assets[/media/gpxsymbols<br/>display.css + symbol sprites]
+    Grid[Rendered symbol grid]
+
+    Display --> Loader
+    Loader --> Assets
+    Display --> Grid
+```
+
+### Related HLD Documents
+- [media/gpxsymbols HLD](../media/gpxsymbols/HLD.md) - Symbol existence endpoint and asset inventory

--- a/ics/HLD.md
+++ b/ics/HLD.md
@@ -142,12 +142,31 @@ sequenceDiagram
 ## Integration Points
 
 ### Used By
-- **REventFeed**: Generates ICS output → [event HLD](../event/HLD.md)
-- **REventGroup**: Calls `getIcalendarFile()` → [event HLD](../event/HLD.md)
-- **RJsonwalksWalk**: `Event_ics()` method generates walk ICS records → [jsonwalks/walk HLD](../jsonwalks/walk/HLD.md)
+- **REventFeed** for ICS output → [event HLD](../event/HLD.md#integration-points).
+- **REventGroup** when exporting aggregated events → [event HLD](../event/HLD.md#integration-points).
+- **RJsonwalksWalk::Event_ics()** to write per-walk fields → [jsonwalks/walk HLD](../jsonwalks/walk/HLD.md#integration-points).
 
-### Dependencies
-- **PHP mbstring**: Unicode string handling for `chunk_split_unicode()`
+### Uses
+- **PHP mbstring** for Unicode handling in `chunk_split_unicode()`.
+
+### Data Sources
+- **Walk/event data** supplied through `REventGroup` and `RJsonwalksWalk` objects.
+
+### External Services
+- None; pure server-side string generation.
+
+### Display Layer
+- **Server**: Emits ICS text/headers for download via `RIcsFile` or controller output.
+- **Client**: ICS files consumed by calendar apps; no browser assets.
+
+### Joomla Integration
+- ICS responses are delivered through Joomla controllers/views; headers set for downloads.
+
+### Vendor Library Integration
+- None.
+
+### Media Asset Relationships
+- None; no JS/CSS loaded for ICS generation.
 
 ## Media Dependencies
 
@@ -231,5 +250,4 @@ $escaped = RIcsOutput::escapeString($text);
 ### Standards
 - **RFC5545**: iCalendar specification
 - **RFC7986**: iCalendar extensions
-
 

--- a/jsonwalks/HLD.md
+++ b/jsonwalks/HLD.md
@@ -293,26 +293,37 @@ sequenceDiagram
 
 ## Integration Points
 
-### Data Sources
-- **Walk Manager**: `RJsonwalksSourcewalksmanager` → `RJsonwalksWmFeed` → [jsonwalks/wm HLD](wm/ARCHITECTURE.md)
-- **Area-based WM**: `RJsonwalksSourcewalksmanagerarea` → extends sourcewalksmanager
-- **Local Editor**: `RJsonwalksSourcewalkseditor` → local walk data
+### Used By
+- **jsonwalks/std presenters** consume `RJsonwalksFeed` and `RJsonwalksWalks` for tabbed/list/table displays → [jsonwalks/std HLD](std/HLD.md#integration-points).
+- **jsonwalks/leaflet map marker display** pulls walk collections to create map payloads → [jsonwalks/leaflet HLD](leaflet/HLD.md#integration-points).
+- **ICS/Event exports** in `REventGroup` rely on `RJsonwalksFeed::displayIcsDownload()` to populate events → [event HLD](../event/HLD.md#integration-points).
 
-### Display Layer
-- **Base Class**: `RJsonwalksDisplaybase` → abstract base for all presenters
-- **Standard Displays**: [jsonwalks/std HLD](std/HLD.md) for implementation details
-- **Map Integration**: `RJsonwalksLeafletMapmarker` → [jsonwalks/leaflet HLD](leaflet/HLD.md)
+### Uses
+- **Data source adapters**: `RJsonwalksSourcewalksmanager`, `RJsonwalksSourcewalksmanagerarea`, `RJsonwalksSourcewalkseditor` → [jsonwalks/wm HLD](wm/HLD.md#integration-points).
+- **Display base/presenters**: `RJsonwalksDisplaybase` and concrete presenters → [jsonwalks/std HLD](std/HLD.md#integration-points) and [jsonwalks/leaflet HLD](leaflet/HLD.md#integration-points).
+- **Shared services**: `RLoad` for asset injection → [load HLD](../load/HLD.md#integration-points); `RErrors` for surfacing issues → [errors HLD](../errors/HLD.md#integration-points); `RGeometryGreatcircle` for distance filtering → [geometry HLD](../geometry/HLD.md#integration-points); `RLeafletMap`/`RLeafletScript` for map assets → [leaflet HLD](../leaflet/HLD.md#integration-points).
+
+### Data Sources
+- **Walk Manager API** via `RJsonwalksSourcewalksmanager` → [jsonwalks/wm HLD](wm/HLD.md#data-sources).
+- **Area-based WM queries** via `RJsonwalksSourcewalksmanagerarea` (same feed/cache path as WM).
+- **Local editor data** via `RJsonwalksSourcewalkseditor` (site-local JSON).
 
 ### External Services
-- **Leaflet Maps**: `RLeafletMap`, `RLeafletScript` → [leaflet HLD](../leaflet/HLD.md)
-- **Asset Loading**: `RLoad` → [load HLD](../load/HLD.md)
-- **Error Handling**: `RErrors` → [errors HLD](../errors/HLD.md)
-- **Geometry**: `RGeometryGreatcircle` → used for distance filtering → [geometry HLD](../geometry/HLD.md)
+- **Walk Manager HTTPS endpoint** for walk/event data (API key managed in source adapters).
 
-### Domain Model
-- **Walk Components**: See [jsonwalks/walk HLD](walk/HLD.md) for detailed value object structure
+### Display Layer
+- **Server presenters**: `RJsonwalksStdDisplay`, `RJsonwalksStdSimplelist`, `RJsonwalksStdWalktable`, `RJsonwalksStdCancelledwalks`, and `RJsonwalksLeafletMapmarker` render `RJsonwalksWalks` → [jsonwalks/std HLD](std/HLD.md#data-flow) and [jsonwalks/leaflet HLD](leaflet/HLD.md#data-flow).
+- **Client bootstrap**: Uses commands such as `ra.display.walksTabs`/`walksMap` emitted by display classes to start browser-side rendering → [media/jsonwalks HLD](../media/jsonwalks/HLD.md#integration-points).
 
-## Server-to-Client Asset Relationship
+### Joomla Integration
+- **Module/page entry**: Feed instantiated by Joomla module params and page scripts.
+- **Document pipeline**: `RLoad` injects CSS/JS with cache-busting; `RLeafletScript` adds map bootstrap scripts; Joomla messaging surface used by `RErrors`.
+
+### Vendor Library Integration
+- **Leaflet stack** via `RLeafletScript` (CDN + `/media/leaflet` plugins) → [leaflet HLD](../leaflet/HLD.md#vendor-library-integration).
+- **cvList** pagination and FullCalendar for tabbed displays loaded from `/media/vendors` → [media/vendors HLD](../media/vendors/HLD.md#integration-points).
+
+### Media Asset Relationships
 
 ```mermaid
 flowchart LR
@@ -424,7 +435,7 @@ $feed->display($display);
 // RLeafletScript injects Leaflet plus media/jsonwalks/leaflet/mapmarker.js for the Map tab
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Caching Strategy
 - **Walk Manager Data**: Cached at WM feed level (10-minute freshness) → See [jsonwalks/wm HLD](wm/ARCHITECTURE.md)
@@ -479,4 +490,3 @@ $feed->display($display);
 - `jsonwalks/sourcewalksmanager.php` - Walk Manager source adapter
 - `jsonwalks/sourcewalksmanagerarea.php` - Area-based source adapter
 - `jsonwalks/sourcewalkseditor.php` - Local editor source adapter
-

--- a/jsonwalks/std/HLD.md
+++ b/jsonwalks/std/HLD.md
@@ -236,25 +236,37 @@ sequenceDiagram
 
 ## Integration Points
 
-### Parent Classes
-- **RJsonwalksDisplaybase**: Abstract base class → [jsonwalks HLD](../HLD.md)
-  - Provides Leaflet script/options initialization
-  - Defines `DisplayWalks()` contract
+### Used By
+- **jsonwalks/feed orchestration** via `RJsonwalksFeed::display()` to render walk collections → [jsonwalks HLD](../HLD.md#integration-points).
+- **Media/jsonwalks assets** consumed by Joomla modules/pages that embed standard displays → [media/jsonwalks HLD](../../media/jsonwalks/HLD.md#integration-points).
 
-### Leaflet Integration
-- **RLeafletMap**: Map container and data injection → [leaflet HLD](../../leaflet/HLD.md)
-- **RLeafletScript**: Script and asset loading → [leaflet HLD](../../leaflet/HLD.md)
-- **RLoad**: Asset enqueuing → [load HLD](../../load/HLD.md)
+### Uses
+- **Base presenter**: `RJsonwalksDisplaybase` for shared initialization → [jsonwalks HLD](../HLD.md#integration-points).
+- **Map/rendering services**: `RLeafletMap`, `RLeafletScript`, and `RLoad` for asset injection → [leaflet HLD](../../leaflet/HLD.md#integration-points) and [load HLD](../../load/HLD.md#integration-points).
+- **Domain data**: `RJsonwalksWalks` / `RJsonwalksWalk` collections → [jsonwalks/walk HLD](../walk/HLD.md#integration-points).
+- **Structured data**: `RJsonwalksAddschema` for schema.org injection.
+- **Optional bookings**: `Ra_eventbookingHelper` when event booking component is available → [event HLD](../../event/HLD.md#integration-points).
 
 ### Data Sources
-- **RJsonwalksWalks**: Walk collection → [jsonwalks HLD](../HLD.md)
-- **RJsonwalksWalk**: Individual walk objects → [jsonwalks/walk HLD](../walk/HLD.md)
+- **Walk collections** supplied by `RJsonwalksFeed` (from WM/editor sources) → [jsonwalks HLD](../HLD.md#data-sources).
 
-### Schema & Metadata
-- **RJsonwalksAddschema**: Schema.org structured data injection
+### External Services
+- **Leaflet CDN plugins** pulled by `RLeafletScript` for map rendering → [leaflet HLD](../../leaflet/HLD.md#vendor-library-integration).
 
-### Event Booking Integration
-- **Ra_eventbookingHelper**: Optional bookings table display (if component enabled)
+### Display Layer
+- **Server**: Standard presenters emit commands `ra.display.walksTabs`/`walksList`/`tableList`.
+- **Client**: `media/jsonwalks/std/display.js` orchestrates tabs, pagination, calendar, and map rendering using Leaflet → [media/jsonwalks HLD](../../media/jsonwalks/HLD.md#display-layer).
+
+### Joomla Integration
+- **Module/page rendering**: Presenters write HTML into Joomla document and enqueue assets through `RLoad`.
+- **Error surface**: Falls back to Joomla messages when inputs are invalid (e.g., missing walks).
+
+### Vendor Library Integration
+- **cvList** pagination and **FullCalendar** loaded via `display.js` for table and calendar tabs → [media/vendors HLD](../../media/vendors/HLD.md#integration-points).
+- **Leaflet plugins** (clustering, tabs) loaded via `RLeafletScript` to support map tab → [leaflet HLD](../../leaflet/HLD.md#vendor-library-integration).
+
+### Media Asset Relationships
+- Server emits shared `/media/js` utilities (ra.js, ra.tabs.js, ra.walk.js, cvList) before module-specific `/media/jsonwalks/std/display.js`, ensuring tab/pagination scripts are available before the bootstrapper runs.
 
 ## Media Dependencies
 
@@ -360,7 +372,7 @@ class RJsonwalksBU51Tabs extends RJsonwalksStdDisplay {
 }
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Client-Side Rendering
 - **Initial Load**: All walk data sent as JSON payload (can be large for 100+ walks)
@@ -416,5 +428,4 @@ class RJsonwalksBU51Tabs extends RJsonwalksStdDisplay {
 - `media/vendors/fullcalendar-6.1.9/index.global.js` - Calendar view
 - `media/css/ra.tabs.css` - Tab styles
 - `media/vendors/cvList/cvList.css` - Pagination styles
-
 

--- a/jsonwalks/wm/HLD.md
+++ b/jsonwalks/wm/HLD.md
@@ -5,28 +5,33 @@
 The `jsonwalks/wm` module provides the Walks Manager integration layer for Ramblers Library. It builds WM API URLs, retrieves JSON (with retries and gzip support), applies a 10-minute cache window, and hands validated items back to the `jsonwalks` domain for conversion into `RJsonwalksWalk` objects.
 
 **Key Classes (module-owned)**
-- `RJsonwalksWmFeed` – Orchestrates reads from WM API or cache and performs JSON validation.【F:jsonwalks/wm/feed.php†L17-L133】
-- `RJsonwalksWmCachefolder` – Manages cache directory operations (read/write/mtime checks).【F:jsonwalks/wm/cachefolder.php†L14-L65】
-- `RJsonwalksWmFileio` – HTTP/file reader with retry, HTTPS upgrade, gzip, and error redaction.【F:jsonwalks/wm/fileio.php†L9-L69】
-- `RJsonwalksWmFeedoptions` – Builds WM API URLs and deterministic cache filenames.【F:jsonwalks/wm/feedoptions.php†L7-L85】
-- `RJsonwalksWmOrganisation` – Optional source selector based on WM “last updated” timestamps (rarely used in practice).【F:jsonwalks/wm/organisation.php†L13-L113】
+- `RJsonwalksWmFeed` – Orchestrates reads from WM API or cache and performs JSON validation.
+- `RJsonwalksWmCachefolder` – Manages cache directory operations (read/write/mtime checks).
+- `RJsonwalksWmFileio` – HTTP/file reader with retry, HTTPS upgrade, gzip, and error redaction.
+- `RJsonwalksWmFeedoptions` – Builds WM API URLs and deterministic cache filenames.
+- `RJsonwalksWmOrganisation` – Optional source selector based on WM “last updated” timestamps (rarely used in practice).
 
 **Constants**
-- `WALKMANAGER` – Base WM API URL (`https://walks-manager.ramblers.org.uk/api/volunteers/walksevents?`).【F:jsonwalks/wm/feed.php†L9-L21】
-- `APIKEY` – WM API key (redacted in logs via `RJsonwalksWmFileio::setSecretStrings`).【F:jsonwalks/wm/feed.php†L9-L33】
-- `READSOURCE` – Enum for `FEED` vs `CACHE`.【F:jsonwalks/wm/feed.php†L136-L143】
+- `WALKMANAGER` – Base WM API URL (`https://walks-manager.ramblers.org.uk/api/volunteers/walksevents?`).
+- `APIKEY` – WM API key (redacted in logs via `RJsonwalksWmFileio::setSecretStrings`).
+- `READSOURCE` – Enum for `FEED` vs `CACHE`.
 
 ## Component Architecture
 
-```
-Joomla module/page
-        │
-        ▼
-RJsonwalksFeed → RJsonwalksSourcewalksmanager → RJsonwalksWmFeed
-                                                    │
-                                                    ├─ RJsonwalksWmFeedoptions (URL + cache key)
-                                                    ├─ RJsonwalksWmCachefolder (read/write/mtime)
-                                                    └─ RJsonwalksWmFileio (HTTP/local IO, retries)
+```mermaid
+flowchart TB
+    Caller[Joomla module/page]
+    Source[RJsonwalksSourcewalksmanager]
+    Feed[RJsonwalksWmFeed]
+    Options[RJsonwalksWmFeedoptions<br/>URL + cache key]
+    Cache[RJsonwalksWmCachefolder<br/>read/write/mtime]
+    Fileio[RJsonwalksWmFileio<br/>HTTP/local IO, retries]
+
+    Caller --> Source
+    Source --> Feed
+    Feed --> Options
+    Feed --> Cache
+    Feed --> Fileio
 ```
 
 ## RJsonwalksWmFeed (`feed.php`)
@@ -34,54 +39,54 @@ RJsonwalksFeed → RJsonwalksSourcewalksmanager → RJsonwalksWmFeed
 ### Public Interface
 
 - `getGroupFutureItems($groups, $readwalks, $readevents, $readwellbeingwalks): array`  
-  Builds a 12-month date window starting “today”, sets inclusion flags, and delegates to `getFeed` for cache/HTTP retrieval.【F:jsonwalks/wm/feed.php†L25-L50】
+  Builds a 12-month date window starting “today”, sets inclusion flags, and delegates to `getFeed` for cache/HTTP retrieval.
 
 - `getItemsWithinArea($latitude, $longitude, $distance, $readwalks, $readevents, $readwellbeingwalks): array`  
-  Builds an area query (lat/long/radius) and delegates to `getFeed`. Note: both walk/event inclusion flags are mirrored into `include_events/include_walks` before calling WM.【F:jsonwalks/wm/feed.php†L52-L75】
+  Builds an area query (lat/long/radius) and delegates to `getFeed`. Note: both walk/event inclusion flags are mirrored into `include_events/include_walks` before calling WM.
 
 ### Core Behaviour
 
-- **Cache selection**: `whichSource()` returns `CACHE` when a cache file exists and is younger than 10 minutes; otherwise `FEED`. Organisation-based source selection can be toggled by changing `$method`.【F:jsonwalks/wm/feed.php†L85-L118】
-- **Cache fallback**: On feed failure, it will read any existing cache file even if stale; on success it writes the fresh body back to cache.【F:jsonwalks/wm/feed.php†L85-L118】
-- **Validation**: `convertResults()` ensures JSON starts with `{`, decodes, and checks for expected properties before returning `$items->data`; returns `[]` on any failure.【F:jsonwalks/wm/feed.php†L120-L158】
-- **Error reporting**: Errors are routed through `RJsonwalksWmFileio::errorMsg`/`RErrors::notifyError` with API keys redacted.【F:jsonwalks/wm/feed.php†L160-L175】【F:jsonwalks/wm/fileio.php†L9-L69】
+- **Cache selection**: `whichSource()` returns `CACHE` when a cache file exists and is younger than 10 minutes; otherwise `FEED`. Organisation-based source selection can be toggled by changing `$method`.
+- **Cache fallback**: On feed failure, it will read any existing cache file even if stale; on success it writes the fresh body back to cache.
+- **Validation**: `convertResults()` ensures JSON starts with `{`, decodes, and checks for expected properties before returning `$items->data`; returns `[]` on any failure.
+- **Error reporting**: Errors are routed through `RJsonwalksWmFileio::errorMsg`/`RErrors::notifyError` with API keys redacted.
 
 ## RJsonwalksWmFileio (`fileio.php`)
 
 ### Public Interface
 
-- `readFile($urlOrPath)` – Reads HTTP(S) URLs or local files with HTTPS upgrade, gzip support, 3 retry attempts, and an 8s timeout. Returns string or `false`. Secrets registered via `setSecretStrings()` are redacted in errors.【F:jsonwalks/wm/fileio.php†L9-L69】
-- `writeFile($filename, $data)` – Thin wrapper over Joomla file write (used by cache).【F:jsonwalks/wm/fileio.php†L49-L57】
-- `setSecretStrings(array $values)` – Registers secrets to mask in logs.【F:jsonwalks/wm/fileio.php†L13-L17】
+- `readFile($urlOrPath)` – Reads HTTP(S) URLs or local files with HTTPS upgrade, gzip support, 3 retry attempts, and an 8s timeout. Returns string or `false`. Secrets registered via `setSecretStrings()` are redacted in errors.
+- `writeFile($filename, $data)` – Thin wrapper over Joomla file write (used by cache).
+- `setSecretStrings(array $values)` – Registers secrets to mask in logs.
 
 ### Error Handling
 
-Errors are reported through `RErrors::notifyError` with sensitive substrings removed; no exceptions are thrown (callers see `false`).【F:jsonwalks/wm/fileio.php†L28-L44】
+Errors are reported through `RErrors::notifyError` with sensitive substrings removed; no exceptions are thrown (callers see `false`).
 
 ## RJsonwalksWmCachefolder (`cachefolder.php`)
 
 ### Responsibilities
 
-- Ensures the cache directory exists under `JPATH_SITE/cache/<name>`.【F:jsonwalks/wm/cachefolder.php†L14-L28】
-- Provides `fileExists`, `readFile`, `writeFile`, and `lastModified` helpers for cache management.【F:jsonwalks/wm/cachefolder.php†L28-L65】
+- Ensures the cache directory exists under `JPATH_SITE/cache/<name>`.
+- Provides `fileExists`, `readFile`, `writeFile`, and `lastModified` helpers for cache management.
 - Used by `RJsonwalksWmFeed` to decide freshness and to persist successful feed reads.
 
 ## RJsonwalksWmFeedoptions (`feedoptions.php`)
 
 ### Responsibilities
 
-- Holds query parameters (group codes, date range, inclusion flags, area search).【F:jsonwalks/wm/feedoptions.php†L7-L57】
-- Builds the WM API URL via `getFeedURL()` (uses `http_build_query`) and constructs deterministic cache filenames via `getCacheFileName($extension)`.【F:jsonwalks/wm/feedoptions.php†L57-L85】
+- Holds query parameters (group codes, date range, inclusion flags, area search).
+- Builds the WM API URL via `getFeedURL()` (uses `http_build_query`) and constructs deterministic cache filenames via `getCacheFileName($extension)`.
 
 ### Key Properties
 
-`groupCode`, `include_walks`, `include_events`, `include_wellbeing_walks`, `latitude`, `longitude`, `distance`, `date_start`, `date_end`.【F:jsonwalks/wm/feedoptions.php†L7-L57】
+`groupCode`, `include_walks`, `include_events`, `include_wellbeing_walks`, `latitude`, `longitude`, `distance`, `date_start`, `date_end`.
 
 ## RJsonwalksWmOrganisation (`organisation.php`)
 
 ### Role
 
-Optional helper that can choose FEED vs CACHE based on WM group “last updated” timestamps. It is wired into `RJsonwalksWmFeed` but bypassed when `$method === "time"` (the default).【F:jsonwalks/wm/feed.php†L81-L91】【F:jsonwalks/wm/organisation.php†L13-L113】
+Optional helper that can choose FEED vs CACHE based on WM group “last updated” timestamps. It is wired into `RJsonwalksWmFeed` but bypassed when `$method === "time"` (the default).
 
 ## Data Flow (time-based mode)
 
@@ -95,14 +100,59 @@ RJsonwalksFeedoptions → RJsonwalksSourcewalksmanager → RJsonwalksWmFeed
    → returned to Source → converted to RJsonwalksWalk → presenters
 ```
 
-## Error Handling Philosophy
+## Integration Points
 
-- Graceful degradation: return `[]` on failure; never throw.
-- Redacted logging: API keys are masked in error output.
-- Cache-first resilience: stale cache is used when WM API is unavailable.
+### Used By
+- **RJsonwalksSourcewalksmanager** to fetch WM data for the jsonwalks domain → [jsonwalks HLD](../HLD.md#integration-points).
+- **RJsonwalksFeedoptions** consumers in presenters that need WM query URLs → [jsonwalks/std HLD](../std/HLD.md#integration-points).
+
+### Uses
+- **RErrors** for telemetry and user messages → [errors HLD](../../errors/HLD.md#integration-points).
+- **RFeedhelper**-style patterns for caching and IO via `RJsonwalksWmFileio` and `RJsonwalksWmCachefolder`.
+
+### Data Sources
+- **Walk Manager API** (`WALKMANAGER`) with API key injection.
+- **Local cache** under `JPATH_SITE/cache/<name>` for 10-minute freshness windows.
+
+### External Services
+- **Walk Manager** HTTPS endpoint for walks/events/wellbeing data.
+
+### Display Layer
+- **Server only**: Returns arrays to the jsonwalks domain; rendered later by presenters → [media/jsonwalks HLD](../../media/jsonwalks/HLD.md#display-layer).
+
+### Joomla Integration
+- **File paths and cache roots** resolved via Joomla constants; messages surfaced through `RErrors`/Joomla messaging.
+
+### Vendor Library Integration
+- None directly; HTTP and file handling rely on PHP/cURL.
+
+### Media Asset Relationships
+- None; this module is server-side.
+
+## Performance Observations
+
+- **Caching**: 10-minute TTL reduces WM traffic; stale cache is reused on failures.
+- **IO cost**: Single HTTP call per refresh; retries add overhead only on failures.
+- **JSON validation**: Simple property checks; negligible CPU cost.
+
+## Error Handling
+
+- **Graceful degradation**: Return empty arrays on errors; never throw.
+- **Redaction**: API keys masked before logging or messaging.
+- **Cache fallback**: Reads stale cache when WM is unavailable.
 
 ## Testing/Mocking Hooks
 
 - Mock `RJsonwalksWmFileio::readFile()` to simulate API responses/timeouts.
 - Inject test cache files and vary mtimes to exercise `whichSource()`.
 - Verify redaction by registering dummy secrets via `setSecretStrings()`.
+
+## References
+
+- [jsonwalks HLD](../HLD.md) – Feed orchestration
+- [jsonwalks/std HLD](../std/HLD.md) – Presenter usage
+- `jsonwalks/wm/feed.php` – RJsonwalksWmFeed
+- `jsonwalks/wm/feedoptions.php` – URL/cache builder
+- `jsonwalks/wm/fileio.php` – HTTP/local IO with retries
+- `jsonwalks/wm/cachefolder.php` – Cache helpers
+- `jsonwalks/wm/organisation.php` – Optional org-based source selector

--- a/leaflet/csv/HLD.md
+++ b/leaflet/csv/HLD.md
@@ -8,6 +8,22 @@ The `leaflet/csv` module provides CSV data source integration for Leaflet maps. 
 
 **Key Class**: `RLeafletCsvList` extends `RLeafletMap`
 
+## Component Architecture
+
+```mermaid
+flowchart TB
+    CsvList[RLeafletCsvList]
+    TableCols[RLeafletTableColumns]
+    Map[RLeafletMap]
+    Script[RLeafletScript]
+    Loader[RLoad]
+
+    CsvList --> TableCols
+    CsvList --> Map
+    Map --> Script
+    Script --> Loader
+```
+
 ## Public Interface
 
 ### RLeafletCsvList
@@ -18,14 +34,51 @@ public function setDisplayOptions($displayOptions)
 public function display()
 ```
 
+## Data Flow
+
+1. Construct with a CSV filename.
+2. `display()` loads CSV rows, maps columns via `RLeafletTableColumns`, and sets the Leaflet command/data.
+3. `RLeafletScript` injects assets; `ra.display.tableList` renders table + map client-side.
+
 ## Integration Points
 
-- **RLeafletMap**: Base map class → [leaflet HLD](../HLD.md)
-- **RLeafletTableColumns**: Column definitions → [leaflet/table HLD](../table/HLD.md)
+### Used By
+- **Leaflet presenters** needing CSV-backed table/map displays → [leaflet HLD](../HLD.md#integration-points).
+
+### Uses
+- **RLeafletMap / RLeafletScript** for map options and asset injection → [leaflet HLD](../HLD.md#joomla-integration).
+- **RLeafletTableColumns** for column mapping → [leaflet/table HLD](../table/HLD.md#integration-points).
+- **RLoad** to enqueue `/media/leaflet` and `/media/js` assets → [media/js HLD](../../media/js/HLD.md#integration-points).
+
+### Data Sources
+- **CSV file** supplied at construction; column definitions from caller or defaults.
+
+### External Services
+- None; local CSV parsing only.
+
+### Display Layer
+- **Client**: `ra.display.tableList` renders table and optional map → [media/leaflet HLD](../../media/leaflet/HLD.md#display-layer).
+
+### Joomla Integration
+- **Document pipeline**: Assets and JSON payload emitted via `RLeafletMap::display()` with cache-busting from `RLoad`.
+
+### Vendor Library Integration
+- **cvList** for pagination → [media/vendors HLD](../../media/vendors/HLD.md#integration-points).
+
+### Media Asset Relationships
+- Server injects `/media/leaflet/table/ramblerstable.js`, `/media/leaflet/gpx/maplist.js` (when map), and `/media/js` foundations before the bootstrapper runs.
+
+## Performance Observations
+- **CSV parsing**: Linear with row count; suited for modest datasets.
+- **Client pagination**: cvList handles large tables reasonably but avoid huge CSVs.
+
+## Error Handling
+- **Missing file**: Generates Joomla error message and halts display.
+- **Invalid columns**: Falls back to defaults or omits unmapped fields.
 
 ## References
 
 - [leaflet HLD](../HLD.md) - Main map system
+- [leaflet/table HLD](../table/HLD.md) - Column mapping
 - `leaflet/csv/list.php` - RLeafletCsvList class
-
 

--- a/leaflet/gpx/HLD.md
+++ b/leaflet/gpx/HLD.md
@@ -11,7 +11,7 @@ The `leaflet/gpx` module provides GPX route file display on Leaflet maps with el
 - `RLeafletGpxMaplist` extends `RLeafletMap` (folder-driven GPX list + map)
 
 **Dependencies (supporting utilities/assets treated as part of the Leaflet stack)**:
-- `RGpxStatistics` / `RGpxJsonlog` / `RGpxFile` / `RGpxStatistic` for folder scanning, caching, and per-file parsing.【F:gpx/statistics.php†L16-L130】
+- `RGpxStatistics` / `RGpxJsonlog` / `RGpxFile` / `RGpxStatistic` for folder scanning, caching, and per-file parsing.
 - Client assets under `media/leaflet/*` (e.g., `gpx/maplist.js`, elevation, draw/upload/download controls) are documented here as part of the Leaflet module’s media surface.
 
 ## Public Interface
@@ -25,7 +25,7 @@ public $imperial = false;
 public $addDownloadLink = "Users";
 ```
 
-**Behaviour**: Validates that the supplied file exists and has a `.gpx` extension, sets `gpxfile` and presentation flags on the data object, and configures the map command to `ra.display.gpxSingle` so the client loads the route with elevation. Downloads are exposed when the file is present; invalid input is surfaced via Joomla messages.【F:leaflet/gpx/map.php†L15-L78】
+**Behaviour**: Validates that the supplied file exists and has a `.gpx` extension, sets `gpxfile` and presentation flags on the data object, and configures the map command to `ra.display.gpxSingle` so the client loads the route with elevation. Downloads are exposed when the file is present; invalid input is surfaced via Joomla messages.
 
 ### RLeafletGpxMaplist (folder index)
 
@@ -43,15 +43,106 @@ public function display();
 ```
 
 **Behaviour**:
-- Builds a folder summary via `RGpxStatistics`, which regenerates `0000gpx_statistics_file.json` when any file newer than the JSON exists; otherwise it reuses the cached JSON for fast loads.【F:leaflet/gpx/maplist.php†L24-L83】【F:gpx/statistics.php†L16-L55】
-- Sorting: by title (default) or by date when `displayAsPreviousWalks` is true.【F:leaflet/gpx/maplist.php†L32-L65】
-- Map options: clustering, elevation, fullscreen, mouseposition, rightclick, fitbounds, print, settings, and mylocation are enabled to support list + map views.【F:leaflet/gpx/maplist.php†L42-L53】
-- Command: publishes `ra.display.gpxFolder` with a data object containing items, download state (0/1/2), folder name, line colour, and presentation flags for the client to render markers, elevation, pagination, and downloads.【F:leaflet/gpx/maplist.php†L67-L83】
-- Assets: enqueues `maplist.js`, tabs, cvList, and shared ramblerslibrary styles to deliver the tabbed table/map UI.【F:leaflet/gpx/maplist.php†L75-L82】
+- Builds a folder summary via `RGpxStatistics`, which regenerates `0000gpx_statistics_file.json` when any file newer than the JSON exists; otherwise it reuses the cached JSON for fast loads.
+- Sorting: by title (default) or by date when `displayAsPreviousWalks` is true.
+- Map options: clustering, elevation, fullscreen, mouseposition, rightclick, fitbounds, print, settings, and mylocation are enabled to support list + map views.
+- Command: publishes `ra.display.gpxFolder` with a data object containing items, download state (0/1/2), folder name, line colour, and presentation flags for the client to render markers, elevation, pagination, and downloads.
+- Assets: enqueues `maplist.js`, tabs, cvList, and shared ramblerslibrary styles to deliver the tabbed table/map UI.
 
 ### Supporting classes
-- **RGpxStatistics**: Scans the configured folder, extracts metadata from each `.gpx` file (and optional `.txt` descriptions), and writes `0000gpx_statistics_file.json` via `RGpxJsonlog`; emits diagnostics during regeneration to aid admins.【F:gpx/statistics.php†L16-L130】
-- **RGpxFile / RGpxStatistic**: Parse GPX contents to compute title/description (with optional GPX metadata), author/date, start/end coordinates, distance, elevation stats, tracks/segments/routes counts, and duration used in the JSON summary.【F:gpx/statistics.php†L79-L130】
+- **RGpxStatistics**: Scans the configured folder, extracts metadata from each `.gpx` file (and optional `.txt` descriptions), and writes `0000gpx_statistics_file.json` via `RGpxJsonlog`; emits diagnostics during regeneration to aid admins.
+- **RGpxFile / RGpxStatistic**: Parse GPX contents to compute title/description (with optional GPX metadata), author/date, start/end coordinates, distance, elevation stats, tracks/segments/routes counts, and duration used in the JSON summary.
+
+## Component Architecture
+
+```mermaid
+flowchart TB
+    Map[RLeafletGpxMap]
+    Maplist[RLeafletGpxMaplist]
+    Stats[RGpxStatistics<br/>RGpxJsonlog]
+    Parser[RGpxFile / RGpxStatistic]
+    Media[/media/leaflet/gpx/maplist.js<br/>Leaflet.Elevation + leaflet-gpx/]
+
+    Maplist --> Stats
+    Stats --> Parser
+    Map --> Media
+    Maplist --> Media
+```
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Map as RLeafletGpxMap(list)
+    participant Stats as RGpxStatistics
+    participant Media as ra.display.gpxFolder/ra.display.gpxSingle
+
+    Caller->>Map: display()/displayPath()
+    alt folder mode
+        Map->>Stats: build 0000gpx_statistics_file.json
+        Stats-->>Map: cached JSON
+        Map->>Media: setCommand('ra.display.gpxFolder') + data
+    else single file
+        Map->>Media: setCommand('ra.display.gpxSingle') + file metadata
+    end
+    Media-->>Caller: HTML + bootstrap with asset list
+```
+
+## Integration Points
+
+### Used By
+- **Leaflet presenters** that need GPX overlays and elevation profiles → [leaflet HLD](../HLD.md#integration-points).
+
+### Uses
+- **RGpxStatistics / RGpxJsonlog / RGpxFile / RGpxStatistic** for folder scanning and JSON cache → [gpx HLD](../../gpx/HLD.md#integration-points).
+- **RLoad / RLeafletScript** to enqueue Leaflet, elevation, and GPX assets → [leaflet HLD](../HLD.md#joomla-integration).
+
+### Data Sources
+- **Local GPX files/folders** provided by callers; optional `.txt` descriptions and GPX metadata feed titles/descriptions.
+
+### External Services
+- None; all IO is local filesystem.
+
+### Display Layer
+- **Server**: `RLeafletGpxMap` / `RLeafletGpxMaplist` prepare commands/data.
+- **Client**: `ra.display.gpxSingle` and `ra.display.gpxFolder` render tracks, markers, and elevation → [media/leaflet HLD](../../media/leaflet/HLD.md#display-layer).
+
+### Joomla Integration
+- **Document pipeline**: Assets and data injected through `RLeafletMap::display()` with cache-busted URLs via `RLoad`.
+
+### Vendor Library Integration
+- **Leaflet.gpx**, **Leaflet.Elevation**, **cvList** for pagination, and Leaflet plugins loaded via `RLeafletScript` → [media/vendors HLD](../../media/vendors/HLD.md#integration-points).
+
+### Media Asset Relationships
+
+```mermaid
+flowchart LR
+    PHP[RLeafletGpxMap / Maplist]
+    Loader[RLeafletScript + RLoad]
+    BaseJS[/media/js foundation]
+    GpxJS[/media/leaflet/gpx/maplist.js]
+    Vendors[/media/vendors<br/>leaflet-gpx + Leaflet.Elevation + cvList]
+    Bootstrap[ra.bootstrapper → ra.display.gpxSingle/gpxFolder]
+
+    PHP --> Loader
+    Loader --> BaseJS
+    Loader --> GpxJS
+    Loader --> Vendors
+    PHP --> Bootstrap
+```
+
+## Performance Observations
+
+- **Cached summaries**: Folder stats regenerate only when GPX files change (mtime newer than `0000gpx_statistics_file.json`).
+- **Client rendering**: Elevation and clustering add cost for very large GPX sets; pagination (cvList) mitigates table load.
+- **Single GPX**: Lightweight; parsing handled client-side by leaflet-gpx.
+
+## Error Handling
+
+- **Missing files**: Validated before emitting commands; errors surfaced via Joomla messages.
+- **Invalid GPX**: Client libraries handle parse failures gracefully; elevation may skip missing data.
+- **Folder access**: Diagnostics printed during regeneration; falls back to existing cache when possible.
 
 ## Media Dependencies
 

--- a/leaflet/json/HLD.md
+++ b/leaflet/json/HLD.md
@@ -8,6 +8,22 @@ The `leaflet/json` module provides JSON data source integration for Leaflet maps
 
 **Key Class**: `RLeafletJsonList` extends `RLeafletMap`
 
+## Component Architecture
+
+```mermaid
+flowchart TB
+    JsonList[RLeafletJsonList]
+    TableCols[RLeafletTableColumns]
+    Map[RLeafletMap]
+    Script[RLeafletScript]
+    Loader[RLoad]
+
+    JsonList --> TableCols
+    JsonList --> Map
+    Map --> Script
+    Script --> Loader
+```
+
 ## Public Interface
 
 ### RLeafletJsonList
@@ -18,14 +34,51 @@ public function setDisplayOptions($displayOptions)
 public function display()
 ```
 
+## Data Flow
+
+1. Construct with JSON array data.
+2. `display()` maps columns, sets Leaflet command/data, and enqueues assets.
+3. Client `ra.display.tableList` renders table and markers.
+
 ## Integration Points
 
-- **RLeafletMap**: Base map class → [leaflet HLD](../HLD.md)
-- **RLeafletTableColumns**: Column definitions → [leaflet/table HLD](../table/HLD.md)
+### Used By
+- **Leaflet presenters** that render JSON-backed table/map displays → [leaflet HLD](../HLD.md#integration-points).
+
+### Uses
+- **RLeafletMap / RLeafletScript** for map setup and asset injection → [leaflet HLD](../HLD.md#joomla-integration).
+- **RLeafletTableColumns** for column definitions → [leaflet/table HLD](../table/HLD.md#integration-points).
+- **RLoad** to enqueue `/media/leaflet` and `/media/js` assets → [media/js HLD](../../media/js/HLD.md#integration-points).
+
+### Data Sources
+- **JSON array** provided by caller; column mapping supplied or defaulted.
+
+### External Services
+- None.
+
+### Display Layer
+- **Client**: `ra.display.tableList` renders table and map markers → [media/leaflet HLD](../../media/leaflet/HLD.md#display-layer).
+
+### Joomla Integration
+- **Document pipeline**: Assets and JSON payload injected via `RLeafletMap::display()` with cache-busting by `RLoad`.
+
+### Vendor Library Integration
+- **cvList** for pagination → [media/vendors HLD](../../media/vendors/HLD.md#integration-points).
+
+### Media Asset Relationships
+- Server enqueues `/media/leaflet/table/ramblerstable.js` and `/media/js` foundations before emitting the bootstrapper.
+
+## Performance Observations
+- **JSON parsing**: Linear with item count; keep payload sizes reasonable.
+- **Client pagination**: Offloads large lists to cvList pagination.
+
+## Error Handling
+- **Invalid JSON structure**: Displays Joomla warning and aborts rendering.
+- **Missing columns**: Unmapped fields are skipped.
 
 ## References
 
 - [leaflet HLD](../HLD.md) - Main map system
+- [leaflet/table HLD](../table/HLD.md) - Column mapping
 - `leaflet/json/list.php` - RLeafletJsonList class
-
 

--- a/leaflet/sql/HLD.md
+++ b/leaflet/sql/HLD.md
@@ -8,6 +8,24 @@ The `leaflet/sql` module provides SQL query data source integration for Leaflet 
 
 **Key Class**: `RLeafletSqlList` extends `RLeafletMap`
 
+## Component Architecture
+
+```mermaid
+flowchart TB
+    SqlList[RLeafletSqlList]
+    TableCols[RLeafletTableColumns]
+    DB[Joomla Database]
+    Map[RLeafletMap]
+    Script[RLeafletScript]
+    Loader[RLoad]
+
+    SqlList --> DB
+    SqlList --> TableCols
+    SqlList --> Map
+    Map --> Script
+    Script --> Loader
+```
+
 ## Public Interface
 
 ### RLeafletSqlList
@@ -18,15 +36,52 @@ public function setDisplayOptions($displayOptions)
 public function display()
 ```
 
+## Data Flow
+
+1. Construct with SQL query string.
+2. `display()` executes query via Joomla DB, maps columns, and prepares Leaflet command/data.
+3. `RLeafletScript` injects assets; client `ra.display.tableList` renders the result.
+
 ## Integration Points
 
-- **RLeafletMap**: Base map class → [leaflet HLD](../HLD.md)
-- **RLeafletTableColumns**: Column definitions → [leaflet/table HLD](../table/HLD.md)
-- **Joomla Database**: Query execution
+### Used By
+- **Leaflet presenters** needing SQL-backed table/map outputs → [leaflet HLD](../HLD.md#integration-points).
+
+### Uses
+- **Joomla Database** for query execution.
+- **RLeafletMap / RLeafletScript** for map setup and asset injection → [leaflet HLD](../HLD.md#joomla-integration).
+- **RLeafletTableColumns** for column definitions → [leaflet/table HLD](../table/HLD.md#integration-points).
+- **RLoad** to enqueue `/media/leaflet` and `/media/js` assets → [media/js HLD](../../media/js/HLD.md#integration-points).
+
+### Data Sources
+- **SQL query results** returned from Joomla DB.
+
+### External Services
+- None beyond the database.
+
+### Display Layer
+- **Client**: `ra.display.tableList` renders table and markers → [media/leaflet HLD](../../media/leaflet/HLD.md#display-layer).
+
+### Joomla Integration
+- **Document pipeline**: Assets and JSON payload emitted via `RLeafletMap::display()` with cache-busting from `RLoad`.
+
+### Vendor Library Integration
+- **cvList** for pagination → [media/vendors HLD](../../media/vendors/HLD.md#integration-points).
+
+### Media Asset Relationships
+- Server enqueues `/media/leaflet/table/ramblerstable.js` and `/media/js` foundations prior to the bootstrapper.
+
+## Performance Observations
+- **Query cost**: Depends on database; limit result sizes for client pagination.
+- **Client pagination**: cvList handles moderate datasets; avoid very large result sets.
+
+## Error Handling
+- **SQL errors**: Surfaced through Joomla DB error handling; display aborted on failure.
+- **Empty result sets**: Render empty table gracefully.
 
 ## References
 
 - [leaflet HLD](../HLD.md) - Main map system
+- [leaflet/table HLD](../table/HLD.md) - Column mapping
 - `leaflet/sql/list.php` - RLeafletSqlList class
-
 

--- a/leaflet/table/HLD.md
+++ b/leaflet/table/HLD.md
@@ -10,6 +10,18 @@ The `leaflet/table` module provides table column definition utilities for Leafle
 - `RLeafletTableColumns` - Column collection
 - `RLeafletTableColumn` - Individual column definition
 
+## Component Architecture
+
+```mermaid
+flowchart TB
+    Columns[RLeafletTableColumns]
+    Column[RLeafletTableColumn]
+    Sources[CSV/JSON/SQL lists]
+
+    Columns --> Column
+    Sources --> Columns
+```
+
 ## Public Interface
 
 ### RLeafletTableColumns
@@ -25,16 +37,47 @@ public function getColumns()
 public function __construct($title, $field)
 ```
 
+## Data Flow
+
+1. Data-source list builds a `RLeafletTableColumns` set.
+2. Columns are serialized into the Leaflet data object.
+3. Client `ra.display.tableList` renders table headers/rows using the definitions.
+
 ## Integration Points
 
-- **RLeafletCsvList**: CSV column definitions → [leaflet/csv HLD](../csv/HLD.md)
-- **RLeafletJsonList**: JSON column definitions → [leaflet/json HLD](../json/HLD.md)
-- **RLeafletSqlList**: SQL column definitions → [leaflet/sql HLD](../sql/HLD.md)
+### Used By
+- **RLeafletCsvList / RLeafletJsonList / RLeafletSqlList** to describe table columns → [leaflet/csv HLD](../csv/HLD.md#integration-points), [leaflet/json HLD](../json/HLD.md#integration-points), [leaflet/sql HLD](../sql/HLD.md#integration-points).
+
+### Uses
+- None beyond simple value storage.
+
+### Data Sources
+- **Column metadata** supplied by callers (title/field).
+
+### External Services
+- None.
+
+### Display Layer
+- **Client**: `ra.display.tableList` consumes column definitions for rendering → [media/leaflet HLD](../../media/leaflet/HLD.md#display-layer).
+
+### Joomla Integration
+- None directly; participates in data objects emitted by Leaflet presenters.
+
+### Vendor Library Integration
+- **cvList** uses column metadata for pagination headers → [media/vendors HLD](../../media/vendors/HLD.md#integration-points).
+
+### Media Asset Relationships
+- None; columns travel as JSON in the Leaflet data payload.
+
+## Performance Observations
+- **Lightweight**: Pure metadata; negligible overhead.
+
+## Error Handling
+- **Invalid columns**: Callers should validate; unused/empty columns simply render blank.
 
 ## References
 
 - [leaflet HLD](../HLD.md) - Main map system
 - `leaflet/table/columns.php` - RLeafletTableColumns class
 - `leaflet/table/column.php` - RLeafletTableColumn class
-
 

--- a/license/HLD.md
+++ b/license/HLD.md
@@ -8,27 +8,78 @@ The `license` module provides license key management for map providers and exter
 
 **Key File**: `license/license.php`
 
+## Component Architecture
+
+```mermaid
+flowchart TB
+    RLicense[RLicense<br/>License lookup]
+    Joomla[Joomla Config<br/>Component params]
+    Consumers[RLeafletMapoptions<br/>Leaflet presenters]
+
+    RLicense --> Joomla
+    RLicense --> Consumers
+```
+
 ## Public Interface
 
-### RLicense (if exists)
+### RLicense
+- **Static methods**:
+  - `getBingMapKey()`
+  - `getESRILicenseKey()`
+  - `getOpenRoutingServiceKey()`
+  - `getOrdnanceSurveyLicenseKey()`
+  - `getMapBoxLicenseKey()`
+  - `getThunderForestLicenseKey()`
+  - `getW3WLicenseKey()`
+- **Behavior**: Each helper reads the corresponding parameter from Joomla component configuration and returns an empty string when unset.
 
-```php
-public static function getBingMapKey()
-public static function getESRILicenseKey()
-public static function getOpenRoutingServiceKey()
-public static function getOrdnanceSurveyLicenseKey()
-public static function getMapBoxLicenseKey()
-public static function getThunderForestLicenseKey()
-public static function getW3WLicenseKey()
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant License as RLicense
+    participant Joomla as Joomla Config
+
+    Caller->>License: get...LicenseKey()
+    License->>Joomla: read component params
+    Joomla-->>License: key or ""
+    License-->>Caller: key string
 ```
 
 ## Integration Points
 
-- **RLeafletMapoptions**: Uses license keys → [leaflet HLD](../leaflet/HLD.md)
+### Used By
+- **RLeafletMapoptions** and map presenters needing provider credentials → [leaflet HLD](../leaflet/HLD.md#integration-points).
+
+### Uses
+- **Joomla configuration**: Reads component parameters to fetch stored keys.
+
+### Data Sources
+- **Site configuration**: Stored API/secret keys for map providers.
+
+### Display Layer
+- None; values are consumed by other PHP classes for client bootstraps.
+
+### Joomla Integration
+- **Component params**: Retrieves keys via `JComponentHelper` (through configuration accessors).
+
+### Vendor Library Integration
+- **Map providers**: Keys feed into Leaflet map options for Bing, ESRI, OS, MapBox, ThunderForest, ORS, and W3W integrations.
+
+### Media Asset Relationships
+- None directly; keys enable downstream asset/service calls in Leaflet presenters.
+
+## Performance Observations
+- **Lightweight**: Simple config lookups; negligible overhead.
+- **Caching**: Relies on Joomla config caching; repeated calls are inexpensive.
+
+## Error Handling
+- **Missing keys**: Return empty strings, allowing callers to disable related features gracefully.
+- **Config access issues**: Fall back to empty string without throwing.
 
 ## References
 
 - `license/license.php` - License key management
 - [leaflet HLD](../leaflet/HLD.md) - License key usage
-
 

--- a/load/HLD.md
+++ b/load/HLD.md
@@ -105,20 +105,29 @@ sequenceDiagram
 ## Integration Points
 
 ### Used By
-- **All display modules**: Load JavaScript and CSS assets
-- **RLeafletScript**: Loads Leaflet assets → [leaflet HLD](../leaflet/HLD.md)
-- **RJsonwalksStdDisplay**: Loads display scripts → [jsonwalks/std HLD](../jsonwalks/std/HLD.md)
-- **RJsonwalksDisplaybase**: Loads base assets → [jsonwalks HLD](../jsonwalks/HLD.md)
+- **All display modules** to enqueue scripts/styles with cache-busting.
+- **RLeafletScript** for Leaflet assets → [leaflet HLD](../leaflet/HLD.md#integration-points).
+- **RJsonwalksStdDisplay / RJsonwalksDisplaybase** for walk display assets → [jsonwalks/std HLD](../jsonwalks/std/HLD.md#integration-points), [jsonwalks HLD](../jsonwalks/HLD.md#integration-points).
+- **Media modules** (accounts, organisation, jsonwalks, leaflet) to load their entry-point JS → see corresponding `media/*/HLD.md` files.
 
-### Dependencies
-- **Joomla Document**: `JFactory::getDocument()` for asset injection
-- **PHP filemtime()**: File modification time retrieval
+### Uses
+- **Joomla Document** via `JFactory::getDocument()->addScript/addStyleSheet`.
+- **Filesystem**: `filemtime()` to derive `rev` query for local files.
 
-## Media Dependencies
+### Data Sources
+- **Asset paths** supplied by callers; may be local or remote URLs.
 
-### No Module-Specific Media Files
+### Display Layer
+- **Server-side** only; outputs `<script>`/`<link>` tags into the Joomla document.
 
-The load module itself has no media files. It loads media files from other modules.
+### Joomla Integration
+- **Document pipeline**: Inserts cache-busted URLs respecting Joomla base paths; remote URLs default to `rev=0`.
+
+### Vendor Library Integration
+- Indirect; loads vendor bundles referenced by callers (e.g., Leaflet, cvList) but does not own vendor logic.
+
+### Media Asset Relationships
+- **Server → Client**: Callers provide asset paths; `RLoad` appends `?rev=<mtime>` for local files before Joomla emits them to the browser.
 
 ## Examples
 
@@ -150,7 +159,7 @@ RLoad::addScript('media/custom/module.js', 'module');
 // Results in: <script type="module" src="...?rev=timestamp"></script>
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Cache-Busting Performance
 - **File System Calls**: `filemtime()` called for each local asset (fast)
@@ -180,5 +189,4 @@ RLoad::addScript('media/custom/module.js', 'module');
 
 ### Key Source Files
 - `load/load.php` - RLoad class
-
 

--- a/media/accounts/HLD.md
+++ b/media/accounts/HLD.md
@@ -108,18 +108,27 @@ sequenceDiagram
 
 ## Integration Points
 
-### PHP Integration
-- **RAccounts**: Provides account data and calls `RLoad::addScript()` to enqueue `/media/accounts/accounts.js` and the shared `/media/js` stack before rendering the Leaflet map → [accounts HLD](../../accounts/HLD.md)
-- **RLeafletMap**: Hosts the map container and injects JSON data/command for `ra.display.accountsMap` → [leaflet HLD](../../leaflet/HLD.md)
+### Used By
+- **RAccounts::addMapMarkers()**: PHP helper that sets the map command/data and renders the hosted sites map → [accounts HLD](../../accounts/HLD.md#integration-points).
 
-### Core JavaScript Integration
-- **ra.js**: Bootstrapper and utilities → [media/js HLD](../js/HLD.md)
-- **ra.leafletmap.js**: Map wrapper → [media/leaflet HLD](../leaflet/HLD.md)
-- **ra.map.cluster**: Marker clustering → [media/leaflet HLD](../leaflet/HLD.md)
+### Uses
+- **RLoad**: Enqueues `/media/accounts/accounts.js` plus `/media/js` foundations → [load HLD](../../load/HLD.md#integration-points).
+- **RLeafletMap**: Provides map options, command, and JSON payload to the browser → [leaflet HLD](../../leaflet/HLD.md#integration-points).
+- **ra.map.cluster**: Clustering helper for marker aggregation → [media/leaflet HLD](../leaflet/HLD.md#integration-points).
 
-## Media Integration
+### Data Sources
+- **Hosted site dataset**: Domain, code, status, group/area names, and coordinates supplied by `RAccounts` → [accounts HLD](../../accounts/HLD.md#data-flow).
 
-### Server-to-Client Asset Relationship
+### Display Layer
+- **Client renderer**: `ra.display.accountsMap` adds markers/popups on `ra.leafletmap` → [media/leaflet HLD](../leaflet/HLD.md#display-layer).
+
+### Joomla Integration
+- **Document pipeline**: Assets and bootstrapper injected into `JDocument` through `RLoad` and `RLeafletMap::display()`.
+
+### Vendor Library Integration
+- **Leaflet.js** and **Leaflet.markercluster** for mapping and clustering.
+
+### Media Asset Relationships (Server → Client)
 
 ```mermaid
 flowchart LR
@@ -165,6 +174,16 @@ ra.bootstrapper(
     '{"hostedsites":[...]}'
 );
 ```
+
+## Performance Observations
+- **Clustering** reduces DOM load for large hosted-site sets and keeps interaction responsive.
+- **Data volume** is typically small (one marker per site); performance impact is dominated by Leaflet tile loading.
+- **Asset reuse** leverages cached `/media/js` foundations, minimizing load time.
+
+## Error Handling
+- **Missing or invalid coordinates**: Entries without coordinates are skipped to avoid map errors.
+- **Empty datasets**: The map initializes and displays no markers without failing.
+- **Bootstrap issues**: `ra.display.accountsMap` validates required data and surfaces errors if the command or container is missing.
 
 ## References
 

--- a/media/gpxsymbols/HLD.md
+++ b/media/gpxsymbols/HLD.md
@@ -82,29 +82,34 @@ sequenceDiagram
 
 ## Integration Points
 
-### JavaScript Integration
-- **GPX Display**: Used by GPX symbol display to check symbol availability
-- **Map Markers**: Used when displaying waypoint symbols
+### PHP Integration
+- **exists.php endpoint**: Provides a lightweight file existence check used by GPX symbol renderers → [gpxsymbols HLD](../../gpxsymbols/HLD.md)
 
-### File System
-- **Symbol Directories**: 
-  - `media/gpxsymbols/letter/` - Letter symbols (a-z)
-  - `media/gpxsymbols/number/` - Number symbols (0-100)
-  - `media/gpxsymbols/number_white/` - White number symbols
-  - `media/gpxsymbols/office/` - Office symbols
-  - `media/gpxsymbols/transport/` - Transport symbols
+### Core JavaScript Integration
+- **Callers**: GPX map/marker widgets may call `exists.php` to test for symbol availability before rendering markers.
 
-## Media Dependencies
+## Media Integration
 
-### Symbol Image Files
-- `media/gpxsymbols/letter/*.png` - 26 letter symbols
-- `media/gpxsymbols/number/*.png` - 101 number symbols
-- `media/gpxsymbols/number_white/*.png` - 101 white number symbols
-- `media/gpxsymbols/office/*.png` - 74 office symbols
-- `media/gpxsymbols/transport/*.png` - 101 transport symbols
+### Server-to-Client Asset Relationship
 
-### CSS Dependencies
-- `media/gpxsymbols/display.css` - Symbol display styles
+```mermaid
+flowchart LR
+    Client[Client widget]
+    Exists[media/gpxsymbols/exists.php]
+    Files[/media/gpxsymbols<br/>symbol sprites]
+    Response["true" / "false"]
+
+    Client --> Exists
+    Exists --> Files
+    Exists --> Response
+```
+
+`exists.php` responds synchronously with a boolean string so client code can decide whether to reference a given symbol image under `/media/gpxsymbols/*`.
+
+### Key Features (`exists.php`)
+- Sanitizes incoming file paths before checking the filesystem.
+- Returns plain-text `"true"`/`"false"` for easy consumption by PHP or JavaScript.
+- Supports all symbol families under `/media/lib_ramblers/gpxsymbols/*` without code changes.
 
 ## Examples
 
@@ -153,13 +158,3 @@ fetch('media/lib_ramblers/gpxsymbols/exists.php?file=media/lib_ramblers/gpxsymbo
 
 ### Key Source Files
 - `media/gpxsymbols/exists.php` - Existence check endpoint (18 lines)
-
-### Related Media Files
-- `media/gpxsymbols/display.css` - Symbol stylesheet
-- `media/gpxsymbols/letter/*.png` - Letter symbols (26 files)
-- `media/gpxsymbols/number/*.png` - Number symbols (101 files)
-- `media/gpxsymbols/number_white/*.png` - White number symbols (101 files)
-- `media/gpxsymbols/office/*.png` - Office symbols (74 files)
-- `media/gpxsymbols/transport/*.png` - Transport symbols (101 files)
-
-

--- a/media/gpxsymbols/HLD.md
+++ b/media/gpxsymbols/HLD.md
@@ -82,15 +82,25 @@ sequenceDiagram
 
 ## Integration Points
 
-### PHP Integration
-- **exists.php endpoint**: Provides a lightweight file existence check used by GPX symbol renderers → [gpxsymbols HLD](../../gpxsymbols/HLD.md)
+### Used By
+- **GPX renderers and symbol widgets**: Client code that needs to confirm an icon exists before referencing it → [gpxsymbols HLD](../../gpxsymbols/HLD.md#integration-points).
 
-### Core JavaScript Integration
-- **Callers**: GPX map/marker widgets may call `exists.php` to test for symbol availability before rendering markers.
+### Uses
+- **PHP filesystem**: `file_exists()` for local symbol folders (no additional module dependency).
 
-## Media Integration
+### Data Sources
+- **Query string**: `file` parameter specifying the symbol path to validate (input from client widgets consuming GPX symbols) → [gpxsymbols HLD](../../gpxsymbols/HLD.md#integration-points).
 
-### Server-to-Client Asset Relationship
+### Display Layer
+- **Client callers**: JavaScript or PHP widgets consume the boolean response to decide whether to display a symbol.
+
+### Joomla Integration
+- **Direct endpoint**: Runs within Joomla’s PHP runtime without additional dependencies.
+
+### Vendor Library Integration
+- None.
+
+### Media Asset Relationships (Server → Client)
 
 ```mermaid
 flowchart LR
@@ -128,7 +138,7 @@ fetch('media/lib_ramblers/gpxsymbols/exists.php?file=media/lib_ramblers/gpxsymbo
     });
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### File System Checks
 - **Fast**: `file_exists()` is fast for local files

--- a/media/js/HLD.md
+++ b/media/js/HLD.md
@@ -56,6 +56,44 @@ flowchart TB
     Display --> Walk
 ```
 
+## Integration Points
+
+### PHP Integration
+- **RLoad**: Server-side modules call `RLoad::addScript()` to enqueue the `/media/js` foundation (`ra.js`, `ra.map.js`, `ra.feedhandler.js`, `ra.paginatedDataList.js`, `ra.tabs.js`, `ra.walk.js`) before emitting module-specific scripts → [load HLD](../../load/HLD.md).
+- **Module bootstraps**: Display classes (`RJsonwalksStdDisplay`, `RAccounts`, `ROrganisation`, etc.) set the JavaScript command and data on `RLeafletMap`/`JDocument`, triggering `ra.bootstrapper` in the browser.
+
+### Core JavaScript Integration
+- **Bootstrapper**: `ra.bootstrapper` is invoked from PHP-rendered script declarations to instantiate the requested display class (e.g., `ra.display.walksTabs`, `ra.display.accountsMap`).
+- **Map utilities**: `ra.leafletmap` is consumed by map displays in `/media/accounts`, `/media/organisation`, `/media/jsonwalks`, and `/media/leaflet` bundles.
+- **Pagination/Tabs**: `ra.paginatedDataList` and `ra.tabs` are reused by walk displays and the walkseditor.
+
+## Data Flow
+
+### Server-to-Client Asset Relationship
+
+```mermaid
+flowchart LR
+    PHP[RLoad::addScript]
+    Loader[/media/js<br/>ra.js, ra.map.js, ra.feedhandler.js, ra.paginatedDataList.js, ra.tabs.js, ra.walk.js]
+    Module[Module-specific assets]
+    Document[Joomla Document]
+    Browser[ra.bootstrapper]
+
+    PHP --> Loader
+    PHP --> Module
+    PHP --> Document
+    Document --> Browser
+    Browser --> Loader
+```
+
+Server-side modules enqueue the shared `/media/js` stack via `RLoad` alongside their own assets (e.g., `/media/accounts/accounts.js`). `JDocument` emits the bootstrap script that calls `ra.bootstrapper`, which then instantiates the requested display class and consumes the previously enqueued `/media/js` bundles.
+
+## Key Features
+- Unified bootstrapper (`ra.bootstrapper`) for all Ramblers client displays.
+- Shared utilities for events, loading indicators, modals, filtering, and DOM helpers.
+- Map helpers (`ra.map.*`, `ra.leafletmap`) and icon factories consumed across map-enabled modules.
+- Pagination and tab primitives reused by walk displays and the walkseditor.
+
 ## Public Interface
 
 ### ra.js - Core Library
@@ -295,11 +333,6 @@ The core library is self-contained but integrates with:
 - **Leaflet.js**: Map functionality (loaded separately)
 - **Joomla jQuery**: May be used by some components
 
-### CSS Dependencies
-- `media/css/ra.tabs.css` - Tab styling
-- `media/css/ra.paginatedDataList.css` - Pagination styling
-- `media/css/ramblerslibrary.css` - Base library styles
-
 ## Examples
 
 ### Example 1: Basic Bootstrap
@@ -397,5 +430,3 @@ eventTag.addEventListener("locationfound", function(e) {
 - `media/js/ra.walk.js` - Walk utilities (2286+ lines)
 - `media/js/ra.tabs.js` - Tab system (140+ lines)
 - `media/js/ra.paginatedDataList.js` - Pagination (336+ lines)
-
-

--- a/media/js/HLD.md
+++ b/media/js/HLD.md
@@ -58,14 +58,30 @@ flowchart TB
 
 ## Integration Points
 
-### PHP Integration
-- **RLoad**: Server-side modules call `RLoad::addScript()` to enqueue the `/media/js` foundation (`ra.js`, `ra.map.js`, `ra.feedhandler.js`, `ra.paginatedDataList.js`, `ra.tabs.js`, `ra.walk.js`) before emitting module-specific scripts → [load HLD](../../load/HLD.md).
-- **Module bootstraps**: Display classes (`RJsonwalksStdDisplay`, `RAccounts`, `ROrganisation`, etc.) set the JavaScript command and data on `RLeafletMap`/`JDocument`, triggering `ra.bootstrapper` in the browser.
+## Integration Points
 
-### Core JavaScript Integration
-- **Bootstrapper**: `ra.bootstrapper` is invoked from PHP-rendered script declarations to instantiate the requested display class (e.g., `ra.display.walksTabs`, `ra.display.accountsMap`).
-- **Map utilities**: `ra.leafletmap` is consumed by map displays in `/media/accounts`, `/media/organisation`, `/media/jsonwalks`, and `/media/leaflet` bundles.
-- **Pagination/Tabs**: `ra.paginatedDataList` and `ra.tabs` are reused by walk displays and the walkseditor.
+### Used By
+- **Display modules**: `RJsonwalksStdDisplay`, `RAccounts`, `ROrganisation`, `RWalkseditor`, Leaflet GPX/table/map presenters, and other PHP helpers enqueue `/media/js` as the shared base library → see module HLDs: [jsonwalks/std HLD](../../jsonwalks/std/HLD.md#integration-points), [accounts HLD](../../accounts/HLD.md#integration-points), [organisation HLD](../../organisation/HLD.md#integration-points), [leaflet HLD](../../leaflet/HLD.md#integration-points), [walkseditor HLD](../../walkseditor/HLD.md#integration-points).
+
+### Uses
+- **RLoad**: Publishes the `/media/js` stack (bootstrapper, map helpers, feed handler, pagination, tabs, walk utilities) into `JDocument` → [load HLD](../../load/HLD.md#integration-points).
+- **Bootstrapper**: `ra.bootstrapper` instantiates requested display classes (e.g., `ra.display.walksTabs`, `ra.display.accountsMap`) based on PHP-injected command/data.
+- **Map utilities**: `ra.leafletmap` and `ra.map.*` are consumed by map-enabled bundles across `/media/*` → [media/leaflet HLD](../leaflet/HLD.md#integration-points).
+- **Pagination/Tabs/Walk utilities**: `ra.paginatedDataList`, `ra.tabs`, `ra.walk`, and `ra.feedhandler` are reused by walk displays and the walkseditor → [media/jsonwalks HLD](../jsonwalks/HLD.md#integration-points), [media/walkseditor HLD](../walkseditor/HLD.md#integration-points).
+
+### Data Sources
+- **PHP data payloads**: Command/data objects injected by server-side display classes for walks, accounts, organisations, and GPX payloads → [jsonwalks HLD](../../jsonwalks/HLD.md#data-flow), [accounts HLD](../../accounts/HLD.md#data-flow), [organisation HLD](../../organisation/HLD.md#data-flow), [leaflet/gpx HLD](../../leaflet/gpx/HLD.md#data-flow).
+
+### Display Layer
+- **Client-side renderers**: All `/media/*` display entry points rely on `ra.*` utilities for bootstrapping, filtering, pagination, and map helpers → see specific module HLDs such as [media/jsonwalks HLD](../jsonwalks/HLD.md#display-layer), [media/accounts HLD](../accounts/HLD.md#display-layer), [media/leaflet HLD](../leaflet/HLD.md#display-layer), [media/walkseditor HLD](../walkseditor/HLD.md#display-layer).
+
+### Joomla Integration
+- **Document pipeline**: `RLoad::addScript()` injects cache-busted core scripts into `JDocument` before module-specific assets.
+
+### Vendor Library Integration
+- **cvList**: Pagination backbone for `ra.paginatedDataList` → [media/vendors HLD](../vendors/HLD.md#integration-points).
+- **FullCalendar**: Calendar view support (consumed by walk displays) → [media/vendors HLD](../vendors/HLD.md#integration-points).
+- **Leaflet.js**: Map foundation referenced by `ra.leafletmap` and map helpers → [media/leaflet HLD](../leaflet/HLD.md#integration-points).
 
 ## Data Flow
 
@@ -381,7 +397,7 @@ eventTag.addEventListener("locationfound", function(e) {
 });
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Initialization
 - **Bootstrapper**: Fast dynamic class instantiation

--- a/media/jsonwalks/HLD.md
+++ b/media/jsonwalks/HLD.md
@@ -264,21 +264,32 @@ sequenceDiagram
 
 ## Integration Points
 
-### PHP Integration
-- **RJsonwalksStdDisplay**: Provides walk data/config and enqueues `/media/jsonwalks/std/display.js` plus `/media/js` foundations via `RLoad::addScript()` → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md)
-- **RJsonwalksLeafletMapmarker**: Provides marker data and loads `/media/jsonwalks/leaflet/mapmarker.js` alongside Leaflet via `RLeafletScript::add()` → [jsonwalks/leaflet HLD](../../jsonwalks/leaflet/HLD.md)
-- **RLeafletScript**: Injects Leaflet core/plugins and the `ra.bootstrapper` declaration → [leaflet HLD](../../leaflet/HLD.md)
+### Used By
+- **RJsonwalksStdDisplay**: Provides walk data/config and enqueues `/media/jsonwalks/std/display.js` plus `/media/js` foundations via `RLoad::addScript()` → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md#integration-points).
+- **RJsonwalksLeafletMapmarker**: Provides marker data and loads `/media/jsonwalks/leaflet/mapmarker.js` alongside Leaflet via `RLeafletScript::add()` → [jsonwalks/leaflet HLD](../../jsonwalks/leaflet/HLD.md#integration-points).
 
-### Core JavaScript Integration
-- **ra.js / ra.tabs / ra.paginatedDataList / ra.walk**: Shared foundations loaded before any `/media/jsonwalks/*` entry point → [media/js HLD](../js/HLD.md)
-- **ra.leafletmap + ra.map.cluster**: Map utilities consumed by `mapmarker.js` → [media/leaflet HLD](../leaflet/HLD.md)
+### Uses
+- **RLeafletScript**: Injects Leaflet core/plugins and the `ra.bootstrapper` declaration → [leaflet HLD](../../leaflet/HLD.md#integration-points).
+- **RLoad**: Enqueues `/media/js` foundations (`ra.js`, `ra.tabs.js`, `ra.paginatedDataList.js`, `ra.walk.js`) before module scripts → [load HLD](../../load/HLD.md#integration-points).
+- **ra.leafletmap + ra.map.cluster**: Map utilities consumed by `mapmarker.js` → [media/leaflet HLD](../leaflet/HLD.md#integration-points).
+
+### Data Sources
+- **Walk JSON payloads** from PHP presenters, including tab/list configuration and legend options → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md#data-flow).
+- **Map options** for clustering, bounds, and legend positioning provided by Leaflet presenters → [leaflet HLD](../../leaflet/HLD.md#data-flow).
+
+### Display Layer
+- **Client entry points**: `ra.display.walksTabs`, `ra.display.walksMap`, and mapmarker-specific displays → [media/js HLD](../js/HLD.md#public-interface).
+- **Shared primitives**: `ra.events` filtering, `ra.tabs` layout, `cvList` pagination → [media/js HLD](../js/HLD.md#integration-points), [media/vendors HLD](../vendors/HLD.md#integration-points).
+
+### Joomla Integration
+- **Document pipeline**: PHP presenters set command/data on `JDocument`; `ra.bootstrapper` instantiates display classes with the injected JSON.
 
 ### Vendor Library Integration
-- **FullCalendar**: Calendar view (`/media/vendors/fullcalendar-6.1.9/`)
-- **cvList**: Pagination library (`/media/vendors/cvList/`)
-- **Leaflet.js**: Map rendering (loaded by `RLeafletScript`)
+- **FullCalendar** (`/media/vendors/fullcalendar-6.1.9/`) for calendar view.
+- **cvList** (`/media/vendors/cvList/`) for pagination.
+- **Leaflet.js** via `RLeafletScript` for map rendering.
 
-## Media Integration
+### Media Asset Relationships (Server → Client)
 
 ### Server-to-Client Asset Relationship
 
@@ -378,7 +389,7 @@ var result = displayCustomValues("{xSymbol}", walk);
 // Returns: '<img src=".../Sandwich-icon.png" .../>' if picnic detected
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Client-Side Rendering
 - **Initial Load**: All walk data sent as JSON (can be large for 100+ walks)

--- a/media/jsonwalks/HLD.md
+++ b/media/jsonwalks/HLD.md
@@ -265,56 +265,52 @@ sequenceDiagram
 ## Integration Points
 
 ### PHP Integration
-- **RJsonwalksStdDisplay**: Provides walk data and configuration → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md)
-- **RJsonwalksLeafletMapmarker**: Provides map marker data → [jsonwalks/leaflet HLD](../../jsonwalks/leaflet/HLD.md)
-- **RLeafletScript**: Injects bootstrap code → [leaflet HLD](../../leaflet/HLD.md)
+- **RJsonwalksStdDisplay**: Provides walk data/config and enqueues `/media/jsonwalks/std/display.js` plus `/media/js` foundations via `RLoad::addScript()` → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md)
+- **RJsonwalksLeafletMapmarker**: Provides marker data and loads `/media/jsonwalks/leaflet/mapmarker.js` alongside Leaflet via `RLeafletScript::add()` → [jsonwalks/leaflet HLD](../../jsonwalks/leaflet/HLD.md)
+- **RLeafletScript**: Injects Leaflet core/plugins and the `ra.bootstrapper` declaration → [leaflet HLD](../../leaflet/HLD.md)
 
 ### Core JavaScript Integration
-- **ra.js**: Core utilities, bootstrapper, events → [media/js HLD](../js/HLD.md)
-- **ra.tabs.js**: Tab system → [media/js HLD](../js/HLD.md)
-- **ra.paginatedDataList.js**: Pagination → [media/js HLD](../js/HLD.md)
-- **ra.walk.js**: Walk utilities → [media/js HLD](../js/HLD.md)
+- **ra.js / ra.tabs / ra.paginatedDataList / ra.walk**: Shared foundations loaded before any `/media/jsonwalks/*` entry point → [media/js HLD](../js/HLD.md)
+- **ra.leafletmap + ra.map.cluster**: Map utilities consumed by `mapmarker.js` → [media/leaflet HLD](../leaflet/HLD.md)
 
 ### Vendor Library Integration
-- **FullCalendar**: Calendar view (`media/vendors/fullcalendar-6.1.9/`)
-- **cvList**: Pagination library (`media/vendors/cvList/`)
-- **Leaflet.js**: Map rendering (loaded separately)
+- **FullCalendar**: Calendar view (`/media/vendors/fullcalendar-6.1.9/`)
+- **cvList**: Pagination library (`/media/vendors/cvList/`)
+- **Leaflet.js**: Map rendering (loaded by `RLeafletScript`)
 
-### Leaflet Integration
-- **ra.leafletmap.js**: Map wrapper → [media/leaflet HLD](../leaflet/HLD.md)
-- **ra.map.cluster**: Marker clustering → [media/leaflet HLD](../leaflet/HLD.md)
+## Media Integration
 
-## Media Dependencies
+### Server-to-Client Asset Relationship
 
-### JavaScript Files
+```mermaid
+flowchart LR
+    PHP[RJsonwalksStdDisplay<br/>RJsonwalksLeafletMapmarker]
+    Loader[RLoad::addScript]
+    Leaflet[RLeafletScript::add]
+    BaseJS[/media/js<br/>ra.js, ra.tabs.js, ra.paginatedDataList.js, ra.walk.js]
+    StdJS[/media/jsonwalks/std/display.js]
+    MapJS[/media/jsonwalks/leaflet/mapmarker.js]
+    Bootstrap[ra.bootstrapper → ra.display.walksTabs / ra.display.walksMap]
 
-#### `media/jsonwalks/std/display.js`
-- **Purpose**: Standard tabbed walk display
-- **Dependencies**: `ra.js`, `ra.tabs.js`, `ra.walk.js`, `ra.paginatedDataList.js`, FullCalendar, cvList
-- **Size**: 493 lines
-- **Key Features**: 
-  - Tabbed interface (Grades, Table, List, Calendar, Map)
-  - Client-side filtering
-  - Pagination
-  - Print functionality
-  - Calendar integration
+    PHP --> Loader
+    Loader --> BaseJS
+    Loader --> StdJS
+    PHP --> Leaflet
+    Leaflet --> MapJS
+    PHP --> Bootstrap
+```
 
-#### `media/jsonwalks/leaflet/mapmarker.js`
-- **Purpose**: Map marker display
-- **Dependencies**: `ra.js`, `ra.leafletmap.js`, Leaflet.js
-- **Size**: 75 lines
-- **Key Features**: 
-  - Marker clustering
-  - Walk marker rendering
-  - Map zoom to bounds
+`RJsonwalksStdDisplay` adds the shared `/media/js` stack and `/media/jsonwalks/std/display.js` through `RLoad`, while map presenters call `RLeafletScript::add()` to load Leaflet and `/media/jsonwalks/leaflet/mapmarker.js`. The emitted bootstrapper instantiates `ra.display.walksTabs` or `ra.display.walksMap` with the walk data payload.
 
-#### `media/jsonwalks/ml/script.js`
-- **Purpose**: Monthly listing with print
-- **Dependencies**: `ra.js`, `ra.html`
-- **Size**: 69 lines
-- **Key Features**: 
-  - Print functionality
-  - View toggle (All walks / 5 weeks)
+### JavaScript Entry Points
+- **Standard display**: `/media/jsonwalks/std/display.js` (`ra.display.walksTabs`)
+- **Map display**: `/media/jsonwalks/leaflet/mapmarker.js` (`ra.display.walksMap`)
+- **Monthly listing**: `/media/jsonwalks/ml/script.js`
+- **SR02 display**: `/media/jsonwalks/sr02/display.js`
+- **Key Features (shared)**: 
+  - Print functionality and tabbed view toggling (All walks / 5 weeks)
+  - Reuses `ra.events` for filtering and booking awareness
+  - Consumes Leaflet and FullCalendar when those views are enabled
 
 #### `media/jsonwalks/sr02/display.js`
 - **Purpose**: SR02 custom display format
@@ -325,21 +321,28 @@ sequenceDiagram
   - Grade-based styling
   - Picnic/Pub icon detection
 
-### CSS Dependencies
-- `media/css/ra.tabs.css` - Tab styling
-- `media/css/ra.paginatedDataList.css` - Pagination styling
-- `media/css/ramblerslibrary.css` - Base styles
-- `media/jsonwalks/bu51/bu51style.css` - BU51 styles (if used)
-- `media/jsonwalks/sr02/style.css` - SR02 styles
-- `media/jsonwalks/ml/style.css` - Monthly listing styles
+#### `media/jsonwalks/std/display.js`
+- **Purpose**: Standard tabbed walk display
+- **Dependencies**: `ra.js`, `ra.tabs.js`, `ra.paginatedDataList.js`, `ra.walk.js`, FullCalendar, cvList
+- **Key Features**:
+  - Tabbed Grades/Table/List/Calendar/Map views
+  - Client-side filtering with `ra.events`
+  - Pagination via cvList and optional bookings table rendering
 
-### Image Dependencies
-- `media/images/marker-start.png` - Start marker
-- `media/images/marker-cancelled.png` - Cancelled marker
-- `media/images/marker-area.png` - Area marker
-- `media/jsonwalks/sr02/images/grades/*.jpg` - Grade images
-- `media/jsonwalks/sr02/Sandwich-icon.png` - Picnic icon
-- `media/jsonwalks/sr02/beer.png` - Pub icon
+#### `media/jsonwalks/leaflet/mapmarker.js`
+- **Purpose**: Map marker display for walks
+- **Dependencies**: `ra.js`, `ra.leafletmap.js`, Leaflet.js
+- **Key Features**:
+  - Clustered marker rendering with legend support
+  - Zoom-to-bounds across all walk markers
+  - Integrates with `ra.events` to keep filters in sync
+
+#### `media/jsonwalks/ml/script.js`
+- **Purpose**: Monthly listing with print controls
+- **Dependencies**: `ra.js`, `ra.html`
+- **Key Features**:
+  - Adds print button/behavior for monthly views
+  - Simple toggle between condensed and expanded layouts
 
 ## Examples
 
@@ -433,5 +436,3 @@ var result = displayCustomValues("{xSymbol}", walk);
 - `media/jsonwalks/sr02/style.css` - SR02 stylesheet
 - `media/jsonwalks/ml/style.css` - Monthly listing stylesheet
 - `media/jsonwalks/sr02/images/` - SR02 images
-
-

--- a/media/leaflet/HLD.md
+++ b/media/leaflet/HLD.md
@@ -340,14 +340,15 @@ sequenceDiagram
 ## Integration Points
 
 ### PHP Integration
-- **RLeafletMap**: Provides map options and data → [leaflet HLD](../../leaflet/HLD.md)
-- **RLeafletScript**: Injects bootstrap code → [leaflet HLD](../../leaflet/HLD.md)
-- **RLeafletGpxMap**: Provides GPX file path → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md)
+- **RLeafletMap**: Provides map options/data and emits the command/data JSON for client bootstrap → [leaflet HLD](../../leaflet/HLD.md)
+- **RLeafletScript**: Injects Leaflet core/plugins and routes asset enqueueing through `RLoad::addScript()` → [leaflet HLD](../../leaflet/HLD.md)
+- **RLeafletGpxMap**: Supplies GPX file paths for client rendering → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md)
 
 ### Core JavaScript Integration
-- **ra.js**: Core utilities, bootstrapper → [media/js HLD](../js/HLD.md)
-- **ra.map.js**: Map utilities, icons → [media/js HLD](../js/HLD.md)
-- **ra.tabs.js**: Tab system → [media/js HLD](../js/HLD.md)
+- **ra.js / ra.map.js / ra.tabs.js**: Shared foundations loaded before any `/media/leaflet` entry point → [media/js HLD](../js/HLD.md)
+- **ra.leafletmap.js**: Map wrapper used by all client displays.
+- **ra.map.cluster**: Optional clustering helper for map presenters.
+- **ra.paginatedDataList.js**: Used by table-driven map lists.
 
 ### Vendor Library Integration
 - **Leaflet.js**: Core mapping library (CDN)
@@ -365,47 +366,33 @@ sequenceDiagram
 - **Ordnance Survey API**: OS maps and tiles
 - **ESRI**: Aerial imagery
 
-## Media Dependencies
+## Media Integration
 
-### JavaScript Files
+### Server-to-Client Asset Relationship
 
-#### Core Map Files
-- `ra.leafletmap.js` - Map wrapper (395+ lines)
-- `ra.map.settings.js` - Settings panel (114+ lines)
-- `ra.display.plotRoute.js` - Route plotting
-- `ra-display-places.js` - Place display
-- `ra.display.mapCompare.js` - Map comparison
+```mermaid
+flowchart LR
+    PHP[RLeafletScript::add]
+    Loader[RLoad::addScript]
+    BaseJS[/media/js<br/>ra.js, ra.map.js, ra.tabs.js]
+    LeafletJS[Leaflet core + CSS]
+    ModuleJS[/media/leaflet<br/>ra.leafletmap.js, ra.map.settings.js, L.Control.*]
+    Bootstrap[ra.bootstrapper → ra.display.*]
 
-#### Control Files (10+ files)
-- `L.Control.Places.js` - Place management (510+ lines)
-- `L.Control.Search.js` - Location search
-- `L.Control.Tools.js` - Map tools
-- `L.Control.SmartRoute.js` - Smart routing
-- `L.Control.ReverseRoute.js` - Reverse routing
-- `L.Control.GpxUpload.js` - GPX upload
-- `L.Control.GpxDownload.js` - GPX download
-- `L.Control.GpxSimplify.js` - GPX simplification
-- `L.Control.Mouse.js` - Mouse position
-- `L.Control.MyLocation.js` - User location
-- `L.Control.RAContainer.js` - Container control
+    PHP --> Loader
+    Loader --> BaseJS
+    Loader --> LeafletJS
+    Loader --> ModuleJS
+    PHP --> Bootstrap
+```
 
-#### Display Files
-- `gpx/maplist.js` - GPX list display (495+ lines)
-- `table/ramblerstable.js` - Table rendering (358+ lines)
+`RLeafletScript::add()` orchestrates asset loading through `RLoad`, enqueueing the `/media/js` foundation, Leaflet core/CSS, and `/media/leaflet` entry points before outputting the bootstrapper that starts the requested `ra.display.*` class.
 
-### CSS Dependencies
-- `media/leaflet/ramblersleaflet.css` - Base Leaflet styles
-- `media/leaflet/L.Control.Mouse.css` - Mouse control styles
-- `media/leaflet/ra-gpx-tools.css` - GPX tool styles
-
-### Image Dependencies
-- `media/leaflet/images/` - Map icons and markers (58 files)
-  - `postcode-icon.png`, `redmarker.png`, `route-start.png`, etc.
-
-### Map Style Files
-- `media/leaflet/mapStyles/osRamblersStyle.json` - OS Ramblers style
-- `media/leaflet/mapStyles/osTestStyle.json` - OS test style
-- `media/leaflet/mapStyles/osmliberty.json` - OSM Liberty style
+## Key Features (Leaflet Media Stack)
+- `ra.leafletmap.js`: Central map wrapper handling initialization, controls, and data overlays.
+- Control bundle (`L.Control.*`): Search, tools, smart routing, reverse routes, GPX upload/download, mouse position, and more.
+- GPX utilities: `gpx/maplist.js` and elevation integration for displaying and analysing routes.
+- Optional settings panel and comparison displays driven by map options from PHP.
 
 ## Examples
 
@@ -504,5 +491,3 @@ ra.bootstrapper(
 - `media/leaflet/ramblersleaflet.css` - Stylesheet
 - `media/leaflet/images/` - Map icons (58 files)
 - `media/leaflet/mapStyles/` - Map style JSON files
-
-

--- a/media/leaflet/HLD.md
+++ b/media/leaflet/HLD.md
@@ -339,36 +339,33 @@ sequenceDiagram
 
 ## Integration Points
 
-### PHP Integration
-- **RLeafletMap**: Provides map options/data and emits the command/data JSON for client bootstrap → [leaflet HLD](../../leaflet/HLD.md)
-- **RLeafletScript**: Injects Leaflet core/plugins and routes asset enqueueing through `RLoad::addScript()` → [leaflet HLD](../../leaflet/HLD.md)
-- **RLeafletGpxMap**: Supplies GPX file paths for client rendering → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md)
+### Used By
+- **RLeafletMap / RLeafletScript**: PHP bridge that sets map commands/data and enqueues `/media/leaflet` assets before emitting the bootstrapper → [leaflet HLD](../../leaflet/HLD.md#integration-points).
+- **RLeafletGpxMap / RLeafletGpxMaplist**: Supply GPX payloads and options for `ra.display.gpxSingle` and related displays → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md#integration-points).
+- **RLeafletMapdraw**: Publishes draw controls for `ra.display.plotRoute` → [leaflet HLD](../../leaflet/HLD.md#integration-points).
 
-### Core JavaScript Integration
-- **ra.js / ra.map.js / ra.tabs.js**: Shared foundations loaded before any `/media/leaflet` entry point → [media/js HLD](../js/HLD.md)
-- **ra.leafletmap.js**: Map wrapper used by all client displays.
-- **ra.map.cluster**: Optional clustering helper for map presenters.
-- **ra.paginatedDataList.js**: Used by table-driven map lists.
+### Uses
+- **RLoad**: Adds `/media/js` foundations plus `/media/leaflet` scripts/styles with cache-busting → [load HLD](../../load/HLD.md#integration-points).
+- **Leaflet core** and plugins (markercluster, GPX, elevation, draw, fullscreen) → [leaflet HLD](../../leaflet/HLD.md#integration-points).
+- **MapLibre GL** and **Proj4js** for vector tiles and projection handling → [leaflet HLD](../../leaflet/HLD.md#integration-points).
+- **places.walkinginfo.co.uk** API for place lookups when place controls are enabled → [leaflet HLD](../../leaflet/HLD.md#data-sources).
+
+### Data Sources
+- **GPX files**: Provided by PHP via data object for `ra.display.gpxSingle` and `gpx/maplist.js` → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md#data-flow).
+- **Table/CSV/JSON lists**: Passed from PHP table/CSV/JSON helpers to `ra.display.tableList` → [leaflet HLD](../../leaflet/HLD.md#data-flow).
+- **Place feeds**: External place API responses consumed by `L.Control.Places` → [media/vendors HLD](../vendors/HLD.md#data-sources).
+
+### Display Layer
+- **Client map wrapper**: `ra.leafletmap` (and `ra._leafletmap`) renders the map, controls, and tabs → [media/js HLD](../js/HLD.md#integration-points).
+- **Display entry points**: `ra.display.gpxSingle`, `ra.display.tableList`, `ra.display.mapCompare`, `ra.display.plotRoute` → [leaflet HLD](../../leaflet/HLD.md#integration-points).
+
+### Joomla Integration
+- **Document pipeline**: `RLeafletScript::add()` injects command/data payloads and calls `RLoad::addScript()`/`addStyleSheet()` to publish assets into `JDocument`.
 
 ### Vendor Library Integration
-- **Leaflet.js**: Core mapping library (CDN)
-- **Leaflet.markercluster**: Marker clustering
-- **Leaflet-gpx**: GPX file parsing
-- **Leaflet.Elevation**: Elevation profiles
-- **Leaflet.draw**: Drawing tools
-- **Leaflet.fullscreen**: Fullscreen control
-- **MapLibre GL**: Vector tiles
-- **Proj4js**: Coordinate projection
+- **Leaflet.js**, **Leaflet.markercluster**, **Leaflet-gpx**, **Leaflet.Elevation**, **Leaflet.draw**, **Leaflet.fullscreen**, **MapLibre GL**, **Proj4js** → [media/vendors HLD](../vendors/HLD.md#integration-points).
 
-### External Services
-- **places.walkinginfo.co.uk**: Place data API
-- **OpenStreetMap**: Geocoding, routing
-- **Ordnance Survey API**: OS maps and tiles
-- **ESRI**: Aerial imagery
-
-## Media Integration
-
-### Server-to-Client Asset Relationship
+### Media Asset Relationships (Server → Client)
 
 ```mermaid
 flowchart LR
@@ -432,7 +429,7 @@ ra.bootstrapper(
 );
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Map Rendering
 - **Tile Loading**: Lazy loading of map tiles (Leaflet handles)

--- a/media/vendors/HLD.md
+++ b/media/vendors/HLD.md
@@ -220,20 +220,31 @@ sequenceDiagram
 
 ## Integration Points
 
-### PHP Integration
-- **RJsonwalksStdDisplay / RWalkseditorProgramme**: Use `RLoad::addScript()` to enqueue `/media/vendors/cvList` alongside `/media/js` before bootstrapping tabbed or paginated displays → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md), [media/walkseditor HLD](../walkseditor/HLD.md)
-- **RLeafletGpxMap / RLeafletMapdraw**: Call `RLoad` from `RLeafletScript::add()` when GPX elevation or drawing features are enabled, pulling in `/media/vendors/Leaflet.Elevation-*` and `/media/vendors/leaflet-gpx-*` bundles → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md), [leaflet/mapdraw.php](../../leaflet/mapdraw.php)
-- **Leaflet Controls**: Map controls that need coordinate conversion rely on `geodesy/*` scripts enqueued through `RLeafletScript`.
+### Used By
+- **RJsonwalksStdDisplay / RWalkseditorProgramme**: PHP callers that enqueue pagination vendors → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md#integration-points), [walkseditor HLD](../../walkseditor/HLD.md#integration-points).
+- **RLeafletGpxMap / RLeafletMapdraw**: PHP map helpers that pull in GPX/elevation/draw vendors → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md#integration-points), [leaflet HLD](../../leaflet/HLD.md#integration-points).
+- **Leaflet controls**: Coordinate-aware controls importing `geodesy` helpers → [media/leaflet HLD](../leaflet/HLD.md#integration-points).
 
-### Core JavaScript Integration
-- **ra.paginatedTable / ra.paginatedList**: Wrap `cvList` to provide pagination UIs in Ramblers components → [media/js HLD](../js/HLD.md)
-- **ra.display.walksTabs**: Uses `cvList` for walk list pagination and FullCalendar for calendar rendering → [media/jsonwalks HLD](../jsonwalks/HLD.md)
-- **ra.display.gpxSingle / L.Control.Elevation**: Layer elevation and GPX parsing via vendor bundles → [media/leaflet HLD](../leaflet/HLD.md)
-- **Leaflet Controls**: `L.Control.Mouse` and `L.Control.Search` import `geodesy` helpers for OS grid conversions → [media/leaflet HLD](../leaflet/HLD.md)
+### Uses
+- **RLoad**: Adds vendor bundles from `/media/vendors/*` with cache-busting → [load HLD](../../load/HLD.md#integration-points).
+- **RLeafletScript**: Delegates loading of Leaflet-adjacent vendor scripts when map features require them → [leaflet HLD](../../leaflet/HLD.md#integration-points).
+- **cvList**, **Leaflet.Elevation**, **leaflet-gpx**, **geodesy** libraries → [media/js HLD](../js/HLD.md#integration-points) for pagination usage, [media/leaflet HLD](../leaflet/HLD.md#integration-points) for mapping usage.
 
-## Media Integration
+### Data Sources
+- **GPX files**: Consumed by `leaflet-gpx` and elevation controls → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md#data-flow).
+- **List/table datasets**: Paged by `cvList` within display modules → [media/js HLD](../js/HLD.md#integration-points).
+- **Coordinate inputs**: Converted by `geodesy` helpers for map controls → [media/leaflet HLD](../leaflet/HLD.md#integration-points).
 
-### Server-to-Client Asset Relationship
+### Display Layer
+- **Client widgets**: Pagination UIs, elevation charts, GPX overlays, and coordinate-aware map controls → [media/jsonwalks HLD](../jsonwalks/HLD.md#display-layer), [media/leaflet HLD](../leaflet/HLD.md#display-layer), [media/js HLD](../js/HLD.md#display-layer).
+
+### Joomla Integration
+- **Document pipeline**: Vendor scripts/styles injected via `RLoad` inside PHP presenters before bootstrap scripts run.
+
+### Vendor Library Integration
+- This module is the vendor collection itself; other modules integrate with these libraries as dependencies (see [media/leaflet HLD](../leaflet/HLD.md#vendor-library-integration) and [media/js HLD](../js/HLD.md#vendor-library-integration)).
+
+### Media Asset Relationships (Server → Client)
 
 ```mermaid
 flowchart LR
@@ -299,7 +310,7 @@ var grid = OsGridRef.latLonToOsGrid(point);
 console.log(grid.toString()); // "TQ 315804 180324"
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### cvList Performance
 - **Client-Side**: All pagination done in browser (fast)

--- a/media/vendors/HLD.md
+++ b/media/vendors/HLD.md
@@ -220,55 +220,42 @@ sequenceDiagram
 
 ## Integration Points
 
-### cvList Integration
-- **ra.paginatedTable**: Uses cvList for table pagination → [media/js HLD](../js/HLD.md)
-- **ra.paginatedList**: Uses cvList for list pagination → [media/js HLD](../js/HLD.md)
-- **ra.display.walksTabs**: Uses cvList for walk list pagination → [media/jsonwalks HLD](../jsonwalks/HLD.md)
+### PHP Integration
+- **RJsonwalksStdDisplay / RWalkseditorProgramme**: Use `RLoad::addScript()` to enqueue `/media/vendors/cvList` alongside `/media/js` before bootstrapping tabbed or paginated displays → [jsonwalks/std HLD](../../jsonwalks/std/HLD.md), [media/walkseditor HLD](../walkseditor/HLD.md)
+- **RLeafletGpxMap / RLeafletMapdraw**: Call `RLoad` from `RLeafletScript::add()` when GPX elevation or drawing features are enabled, pulling in `/media/vendors/Leaflet.Elevation-*` and `/media/vendors/leaflet-gpx-*` bundles → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md), [leaflet/mapdraw.php](../../leaflet/mapdraw.php)
+- **Leaflet Controls**: Map controls that need coordinate conversion rely on `geodesy/*` scripts enqueued through `RLeafletScript`.
 
-### GPX Integration
-- **ra.display.gpxSingle**: Uses L.GPX and L.Control.Elevation → [media/leaflet HLD](../leaflet/HLD.md)
-- **RLeafletGpxMap**: Provides GPX file path → [leaflet/gpx HLD](../../leaflet/gpx/HLD.md)
+### Core JavaScript Integration
+- **ra.paginatedTable / ra.paginatedList**: Wrap `cvList` to provide pagination UIs in Ramblers components → [media/js HLD](../js/HLD.md)
+- **ra.display.walksTabs**: Uses `cvList` for walk list pagination and FullCalendar for calendar rendering → [media/jsonwalks HLD](../jsonwalks/HLD.md)
+- **ra.display.gpxSingle / L.Control.Elevation**: Layer elevation and GPX parsing via vendor bundles → [media/leaflet HLD](../leaflet/HLD.md)
+- **Leaflet Controls**: `L.Control.Mouse` and `L.Control.Search` import `geodesy` helpers for OS grid conversions → [media/leaflet HLD](../leaflet/HLD.md)
 
-### Geodesy Integration
-- **L.Control.Mouse**: Uses OsGridRef for coordinate display → [media/leaflet HLD](../leaflet/HLD.md)
-- **L.Control.Search**: Uses coordinate conversion for location search → [media/leaflet HLD](../leaflet/HLD.md]
-- **Map Controls**: Various controls use geodesy for coordinate conversion
+## Media Integration
 
-## Media Dependencies
+### Server-to-Client Asset Relationship
 
-### cvList Files
-- `cvList/cvList.js` - Main pagination library (954+ lines)
-- `cvList/cvList_ES6.js` - ES6 version
-- `cvList/cvList.css` - Pagination styles
-- `cvList/*.png` - Pagination icons (2 files)
+```mermaid
+flowchart LR
+    PHP[RJsonwalksStdDisplay<br/>RWalkseditorProgramme<br/>RLeafletScript]
+    Loader[RLoad::addScript]
+    Vendors[/media/vendors<br/>cvList, Leaflet.Elevation, leaflet-gpx, geodesy]
+    BaseJS[/media/js foundation]
+    Bootstrap[ra.bootstrapper + map bootstraps]
 
-### Leaflet.Elevation Files
-- `Leaflet.Elevation-0.0.4-ra/leaflet.elevation-0.0.4.src.js` - Elevation control (695+ lines)
-- `Leaflet.Elevation-0.0.4-ra/elevation.css` - Elevation styles
-- `Leaflet.Elevation-0.0.4-ra/*.png` - Elevation icons (6 files)
+    PHP --> Loader
+    Loader --> Vendors
+    Loader --> BaseJS
+    PHP --> Bootstrap
+```
 
-**Customization**: 
-- Custom "steelblue-theme" CSS class
-- Ramblers-specific styling
+Server-side modules call `RLoad` to enqueue vendor bundles from `/media/vendors` alongside the shared `/media/js` foundation. The emitted bootstrap scripts (from `RJsonwalksStdDisplay`, `RWalkseditorProgramme`, or `RLeafletScript`) then initialize pagination widgets, elevation controls, or GPX parsers in the browser.
 
-### leaflet-gpx Files
-- `leaflet-gpx-1.3.1/gpx.js` - GPX parser (543+ lines)
-- `leaflet-gpx-1.3.1/*.png` - GPX icons (4 files)
-
-**Integration**: 
-- Custom icon paths configured
-- Integrated with elevation control
-- Event system for data extraction
-
-### geodesy Files
-- `geodesy/osgridref.js` - OS Grid Reference (331+ lines)
-- `geodesy/latlon-ellipsoidal.js` - Lat/Lon calculations
-- `geodesy/vector3d.js` - 3D vector math
-
-**Integration**: 
-- Used throughout map controls
-- Coordinate display and conversion
-- Location search functionality
+### Key Features (Vendor Bundles)
+- **cvList**: Pagination and sorting utilities wrapped by `ra.paginatedTable`/`ra.paginatedList`.
+- **Leaflet.Elevation**: Charting support for GPX elevation with Ramblers-specific styling hooks.
+- **leaflet-gpx**: GPX parsing with event hooks used by elevation and map displays.
+- **geodesy**: OS grid conversions consumed by Leaflet controls (search, mouse position).
 
 ## Examples
 
@@ -363,5 +350,3 @@ console.log(grid.toString()); // "TQ 315804 180324"
 - **Leaflet.Elevation**: Customized version 0.0.4 with Ramblers theme
 - **leaflet-gpx**: Version 1.3.1, integrated with elevation
 - **geodesy**: Coordinate conversion library by Chris Veness
-
-

--- a/media/walkseditor/HLD.md
+++ b/media/walkseditor/HLD.md
@@ -250,60 +250,73 @@ sequenceDiagram
 ## Integration Points
 
 ### PHP Integration
-- **Joomla Configuration**: Reads email settings from `configuration.php`
-- **PHPMailer Library**: Uses PHPMailer for email sending
-- **JSON Processing**: Receives and validates JSON walk data
+- **RWalkseditorProgramme / RWalkseditorSubmitform**: Call `RWalkseditor::addScriptsandCss()` to enqueue `/media/walkseditor/js/*` plus shared `/media/js/ra.tabs.js` and `/media/vendors/cvList/cvList.js` through `RLoad::addScript()`. Email submission flows through `media/lib_ramblers/walkseditor/sendemail.php` using PHPMailer.
+- **JSON Handling**: Server receives/validates JSON walk data and injects configuration into the client bootstrap.
 
-### JavaScript Integration
-- **ra.js**: Core utilities → [media/js HLD](../js/HLD.md)
-- **Leaflet Maps**: Location selection → [media/leaflet HLD](../leaflet/HLD.md)
-- **AJAX**: Form submission to PHP endpoint
+### Core JavaScript Integration
+- **ra.tabs**: Shared tab UI used by the editor displays → [media/js HLD](../js/HLD.md)
+- **cvList**: Pagination for list views → [media/vendors HLD](../vendors/HLD.md)
+- **Leaflet Maps**: Location picker utilities consume `/media/leaflet` controls when map support is enabled → [media/leaflet HLD](../leaflet/HLD.md)
+- **AJAX Helpers**: Editor scripts post to `sendemail.php` for email delivery.
+
+## Media Integration
+
+### Server-to-Client Asset Relationship
+
+```mermaid
+flowchart LR
+    PHP[RWalkseditorProgramme<br/>RWalkseditorSubmitform]
+    Loader[RLoad::addScript]
+    BaseJS[/media/js/ra.tabs.js<br/>/media/vendors/cvList/cvList.js]
+    EditorJS[/media/walkseditor/js<br/>walkeditor.js, form/*.js]
+    Bootstrap[Client bootstrap + AJAX handlers]
+
+    PHP --> Loader
+    Loader --> BaseJS
+    Loader --> EditorJS
+    PHP --> Bootstrap
+```
+
+`RWalkseditor::addScriptsandCss()` centralizes asset loading by pushing the `/media/walkseditor/js` bundle and shared tab/pagination libraries through `RLoad`. The rendered page then runs the editor bootstrap, which wires the AJAX submission pipeline to `sendemail.php`.
 
 ### External Services
 - **SMTP Server**: Email delivery (via Joomla configuration)
 - **Email Recipients**: Programme coordinators (from form data)
 
-## Media Dependencies
+## Media Dependencies & Key Features
 
 ### JavaScript Files (13 files in `js/` subfolder)
 
 #### Core Editor Files
-- `walkeditor.js` - Main editor (779+ lines)
-- `walk.js` - Walk object handling
-- `viewWalks.js` - Walk viewing interface
-- `inputfields.js` - Form field utilities
-- `loader.js` - Asset loading
+- `walkeditor.js` - Main editor (779+ lines); **Key features**: bootstraps the UI, wires events, orchestrates AJAX.
+- `walk.js` - Walk object handling; **Key features**: domain model, validation helpers.
+- `viewWalks.js` - Walk viewing interface; **Key features**: renders tabbed lists and details.
+- `inputfields.js` - Form field utilities; **Key features**: validation and standardised inputs.
+- `loader.js` - Asset loading; **Key features**: loading overlays and progress feedback.
 
 #### Place Management
-- `placeEditor.js` - Place editing
-- `maplocation.js` - Map location selection
-- `comp/places.js` - Places component
-- `comp/viewAllPlaces.js` - Places list view
+- `placeEditor.js` - Place editing; **Key features**: CRUD helpers and map sync.
+- `maplocation.js` - Map location selection; **Key features**: Leaflet-based picker and coordinate handling.
+- `comp/places.js` - Places component; **Key features**: list rendering and pagination hooks.
+- `comp/viewAllPlaces.js` - Places list view; **Key features**: table rendering and filters.
 
 #### Form Handling
-- `form/submitwalk.js` - Walk submission
-- `form/programme.js` - Programme management
+- `form/submitwalk.js` - Walk submission; **Key features**: validation, payload assembly, and postback.
+- `form/programme.js` - Programme management; **Key features**: programme tab wiring and list refresh.
 
 #### Component Views
-- `comp/viewAllWalks.js` - Walks list view
+- `comp/viewAllWalks.js` - Walks list view; **Key features**: list rendering and pagination with cvList.
 
 #### Utilities
-- `walksEditorHelps.js` - Help system
+- `walksEditorHelps.js` - Help system; **Key features**: contextual tips and modal guidance.
 
 ### PHP Files
 
 #### Email Handling
-- `sendemail.php` - Email submission handler (105 lines)
+- `sendemail.php` - Email submission handler (105 lines); **Key features**: PHPMailer orchestration and JSON response shaping.
 - `PHPMailer.php` - PHPMailer library (5253+ lines)
 - `SMTP.php` - SMTP transport
 - `Exception.php` - Exception classes
-
-### CSS Dependencies
-- `media/walkseditor/css/*.css` - Editor stylesheets (5 files)
-- `media/walkseditor/css/styleemail.css` - Email template styles
-
-### Image Dependencies
-- `media/walkseditor/css/*.png` - Editor icons (6 files)
 
 ## Examples
 
@@ -393,5 +406,3 @@ editor.load(editDiv, walkObject, false);
 ### Related Media Files
 - `media/walkseditor/css/` - Editor stylesheets (5 CSS files)
 - `media/walkseditor/css/*.png` - Editor icons (6 PNG files)
-
-

--- a/organisation/HLD.md
+++ b/organisation/HLD.md
@@ -136,25 +136,30 @@ sequenceDiagram
 
 ## Integration Points
 
+### Used By
+- **ROrganisation::display()** for area/group mapping in Joomla pages/modules → [media/organisation HLD](../media/organisation/HLD.md#integration-points).
+- **RAccounts::updateAccounts()** to enrich hosted-site data with group/area codes → [accounts HLD](../accounts/HLD.md#integration-points).
+
+### Uses
+- **RFeedhelper** for cached HTTP retrieval of the organisation JSON → [feedhelper HLD](../feedhelper/HLD.md#integration-points).
+- **RLeafletMap / RLeafletScript** to set commands/data and enqueue Leaflet assets → [leaflet HLD](../leaflet/HLD.md#integration-points).
+- **RLoad** to add `/media/organisation/organisation.js` plus `/media/js` foundations → [load HLD](../load/HLD.md#integration-points).
+- **RHtml** for tabular display alternatives → [html HLD](../html/HLD.md#integration-points).
+
 ### Data Sources
-- **RFeedhelper**: HTTP feed retrieval → [feedhelper HLD](../feedhelper/HLD.md)
-- **Organisation Feed**: `https://groups.theramblers.org.uk/` JSON endpoint
+- **Organisation Feed**: `https://groups.theramblers.org.uk/` JSON endpoint with areas/groups.
 
 ### Display Layer
-- **RLeafletMap**: Map rendering → [leaflet HLD](../leaflet/HLD.md)
-- **RHtml**: HTML formatting → [html HLD](../html/HLD.md)
+- **Server**: `ROrganisation::display()` prepares map options and JSON payloads.
+- **Client**: `ra.display.organisationMap` renders clustered markers and popups.
 
-### Used By
-- **RAccounts**: Organisation data for account updates → [accounts HLD](../accounts/HLD.md)
+### Joomla Integration
+- **Document pipeline**: Assets and payloads injected via `RLoad` and `RLeafletMap::display()`, respecting Joomla base paths and cache-busting.
 
-### Key Features (`ROrganisation`)
-- Fetches, caches, and converts the organisation feed into area/group domain objects.
-- Provides display configuration flags (links, codes, colours) consumable by client scripts.
-- Emits map-ready JSON and bootstrap commands for `ra.display.organisationMap`.
+### Vendor Library Integration
+- **Leaflet.js + markercluster** loaded through `RLeafletScript`.
 
-## Media Integration
-
-### Server-to-Client Asset Relationship
+### Media Asset Relationships (Server → Client)
 
 ```mermaid
 flowchart LR
@@ -173,15 +178,6 @@ flowchart LR
 ```
 
 `ROrganisation::display()` enqueues `/media/organisation/organisation.js` plus the shared `/media/js` stack through `RLoad`; `RLeafletMap::display()` then injects the bootstrapper, so the browser spins up `ra.display.organisationMap` with the JSON data from PHP.
-
-### Media Asset Loading
-- **JavaScript entry point**: `/media/organisation/organisation.js` (instantiates `ra.display.organisationMap`).
-- **Server-to-client flow**: PHP sets the command/data on `RLeafletMap`, leverages `RLoad` to add `/media` assets, and relies on `RLeafletScript::add()` for Leaflet dependencies before the client bootstrap runs.
-
-### Key Features (`organisation.js`)
-- Renders area and group markers with scope-aware colours and clustering.
-- Popups surface names, codes, descriptions, and links when configured.
-- Supports centring/highlighting a specific group and toggling visibility flags supplied by PHP.
 
 ## Examples
 
@@ -223,16 +219,16 @@ $org->display($map);
 // RLeafletScript adds Leaflet + controls before ra.display.organisationMap runs
 ```
 
-## Performance Notes
+## Performance Observations
 
 ### Data Loading
-- **Caching**: 60-minute TTL via `RFeedhelper`
-- **JSON Parsing**: Fast for typical organisation size (<1000 groups)
-- **Memory**: All areas/groups loaded into memory
+- **Caching**: 60-minute TTL via `RFeedhelper`.
+- **JSON Parsing**: Fast for typical organisation size (<1000 groups).
+- **Memory**: Areas/groups held in memory to support repeated displays.
 
 ### Map Rendering
-- **Marker Clustering**: Used for large datasets
-- **Client-Side**: Map rendering handled by JavaScript
+- **Marker Clustering**: Keeps map interaction responsive for large group counts.
+- **Client-Side**: Rendering handled entirely in JavaScript once payload delivered.
 
 ## Error Handling
 

--- a/walkseditor/HLD.md
+++ b/walkseditor/HLD.md
@@ -6,40 +6,120 @@ The `walkseditor` module provides the walk editing interface for creating and ma
 
 **Purpose**: Walk editing and submission interface.
 
-**Key Files**:
-- `walkseditor/walkseditor.php` - Main asset loader (`RWalkseditor::addScriptsandCss`)
-- `walkseditor/programme.php` - Programme management UI
-- `walkseditor/submitform.php` - Form submission handler
+**Key Features**:
+- Programme management view with tabbed lists and pagination
+- Walk submission form with validation and place editor
+- Shared asset loader that injects JS/CSS and Quill rich-text editor
 
-## Component and Asset Flow
+## Component Architecture
 
 ```mermaid
-flowchart LR
-    Programme[RWalkseditorProgramme<br/>programme.php]
-    Submit[RWalkseditorSubmitform<br/>submitform.php]
-    Loader[RWalkseditor::addScriptsandCss]
-    RLoader[RLoad]
-    BaseTabs[media/js/ra.tabs.js<br/>media/vendors/cvList/cvList.js]
-    EditorJS[media/walkseditor/js/walkeditor.js<br/>walksEditorHelps.js<br/>viewWalks.js]
-    FormJS[media/walkseditor/js/walk.js<br/>inputfields.js<br/>loader.js<br/>maplocation.js<br/>placeEditor.js]
-    ProgrammeJS[media/walkseditor/js/form/programme.js]
-    SubmitJS[media/walkseditor/js/form/submitwalk.js]
-    Styles[media/walkseditor/css/style.css<br/>media/lib_ramblers/css/ra.tabs.css]
-    Quill[cdn.jsdelivr.net/npm/quill@2.0.2]
+flowchart TB
+    subgraph Server["Server Components"]
+        Loader[RWalkseditor<br/>Asset loader]
+        Programme[RWalkseditorProgramme<br/>programme.php]
+        Submit[RWalkseditorSubmitform<br/>submitform.php]
+    end
+
+    subgraph Client["Client Assets"]
+        EditorJS[walkeditor.js<br/>walksEditorHelps.js<br/>viewWalks.js]
+        FormJS[walk.js<br/>inputfields.js<br/>loader.js<br/>maplocation.js<br/>placeEditor.js]
+        ProgrammeJS[form/programme.js]
+        SubmitJS[form/submitwalk.js]
+        CompJS[comp/viewAllWalks.js<br/>comp/viewAllPlaces.js]
+        Foundation[ra.tabs.js<br/>cvList.js]
+        Quill[Quill JS/CSS (CDN)]
+        Styles[style.css<br/>ra.tabs.css]
+    end
 
     Programme --> Loader
     Submit --> Loader
-    Loader --> RLoader
-    RLoader --> BaseTabs
-    RLoader --> EditorJS
-    RLoader --> FormJS
-    RLoader --> ProgrammeJS
-    RLoader --> SubmitJS
-    RLoader --> Styles
-    RLoader --> Quill
+    Loader --> Foundation
+    Loader --> EditorJS
+    Loader --> FormJS
+    Loader --> ProgrammeJS
+    Loader --> SubmitJS
+    Loader --> CompJS
+    Loader --> Styles
+    Loader --> Quill
 ```
 
-`RWalkseditorProgramme::display()` and `RWalkseditorSubmitform::display()` both call `RWalkseditor::addScriptsandCss()`, which uses `RLoad` to enqueue the Ramblers tab/pagination foundation (`media/js/ra.tabs.js`, `media/vendors/cvList/cvList.js`) plus the module-specific editor scripts under `media/walkseditor/js`. The Quill CDN assets are also added to support rich-text editing.
+## Public Interface
+
+### RWalkseditor (asset loader)
+```php
+public static function addScriptsandCss()
+```
+- Adds shared JS/CSS (tabs, pagination) and module scripts (editor, forms, programme, submit) plus Quill assets.
+
+### RWalkseditorProgramme
+```php
+public function display()
+```
+- Renders programme management UI and calls `addScriptsandCss()`.
+
+### RWalkseditorSubmitform
+```php
+public function display()
+```
+- Renders submission form UI and calls `addScriptsandCss()`.
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Joomla as Joomla Page/Module
+    participant Programme as RWalkseditorProgramme
+    participant Submit as RWalkseditorSubmitform
+    participant Loader as RWalkseditor
+    participant RLoad as RLoad
+    participant Browser as Browser
+    participant ClientJS as walkeditor.js/form scripts
+
+    Joomla->>Programme: display()
+    Programme->>Loader: addScriptsandCss()
+    Loader->>RLoad: addScript/addStyle for foundation + editor bundles
+    RLoad-->>Browser: inject assets
+    Browser->>ClientJS: initialize tabs, forms, lists
+
+    Joomla->>Submit: display()
+    Submit->>Loader: addScriptsandCss()
+    Loader->>RLoad: enqueue submit form assets + Quill
+    Browser->>ClientJS: bind validation, map/location pickers
+```
+
+## Integration Points
+
+### Used By
+- **Joomla pages/modules** embedding the walk editor UI → [accounts HLD](../accounts/HLD.md#integration-points) for hosted site admin context.
+- **jsonwalks feed consumers** that ingest edited walks once submitted → [jsonwalks HLD](../jsonwalks/HLD.md#integration-points).
+
+### Uses
+- **RLoad** for asset injection → [load HLD](../load/HLD.md#integration-points).
+- **Quill** rich-text editor (CDN) for description fields.
+- **Ramblers JS foundation** (`ra.tabs.js`, `cvList.js`) for tabs/pagination → [media/js HLD](../media/js/HLD.md#integration-points).
+- **maplocation/placeEditor helpers** rely on Leaflet scripts already present on pages using maps → [leaflet HLD](../leaflet/HLD.md#integration-points).
+
+### Data Sources
+- **Walk data** entered by users; submitted via form handlers to backend processing (outside this module’s HLD scope).
+
+### External Services
+- **Quill CDN** for editor JS/CSS.
+
+### Display Layer
+- **Server**: PHP views emit HTML for forms and lists, enqueue assets via `RWalkseditor::addScriptsandCss()`.
+- **Client**: `walkeditor.js`, `viewWalks.js`, and form scripts render tabs, lists, validation, and map/location pickers → [media/walkseditor HLD](../media/walkseditor/HLD.md#display-layer).
+
+### Joomla Integration
+- Assets injected into the Joomla document via `RLoad` with cache-busting.
+- Uses Joomla module/page context for rendering forms and processing submissions.
+
+### Vendor Library Integration
+- **cvList** pagination from `/media/vendors/cvList`.
+- **Quill** editor from CDN.
+
+### Media Asset Relationships
+- Server loads shared `/media/js` foundation (tabs, pagination) first, then module-specific `/media/walkseditor/js/*` bundles and `/media/walkseditor/css/style.css`, followed by Quill JS/CSS from CDN before client initialization.
 
 ## Media Dependencies
 
@@ -59,6 +139,18 @@ flowchart LR
 - `media/walkseditor/css/style.css` - Editor styling.
 - `media/lib_ramblers/css/ra.tabs.css` - Shared tab styling.
 - CDN: `https://cdn.jsdelivr.net/npm/quill@2.0.2/dist/quill.snow.css` for Quill skin.
+
+## Performance Observations
+
+- **Asset weight**: Multiple JS bundles plus Quill; benefit from browser caching via `RLoad` versioning.
+- **Client workload**: Tabbed list rendering and Quill initialization add startup time; pagination mitigates large lists.
+- **Map/location helpers**: Require Leaflet on pages that need map pickers; avoid initializing when coordinates are not in use.
+
+## Error Handling
+
+- **Missing assets**: If Quill or foundation scripts fail to load, forms fall back to plain inputs; tab UI may degrade gracefully.
+- **Form validation**: Client scripts validate required fields; server-side validation expected in controllers.
+- **Data load errors**: List rendering scripts handle empty datasets by showing empty states rather than crashing.
 
 ## Examples
 
@@ -89,3 +181,10 @@ RWalkseditor::addScriptsandCss(); // Standalone enqueue
 // and media/walkseditor/css/style.css for layout.
 ```
 
+## References
+
+- [accounts HLD](../accounts/HLD.md) - Hosted site context
+- [jsonwalks HLD](../jsonwalks/HLD.md) - Feed consumers of edited walks
+- [media/walkseditor HLD](../media/walkseditor/HLD.md) - Client bundle details
+- [load HLD](../load/HLD.md) - Asset injection
+- [leaflet HLD](../leaflet/HLD.md) - Map utilities leveraged by location pickers


### PR DESCRIPTION
## Summary
- restructure HLDs for accounts, organisation, gpx, errors, load, directory, dns, and license with required sections
- add Used By/Uses cross-links to related module HLDs plus Joomla/vendor/media integration notes
- document data flows, performance observations, and error handling across the reviewed modules
- cross-link media and Leaflet/WM HLD data sources, display layers, and remove line annotations
- extend jsonwalks and Leaflet HLDs with full integration subsections, data flows, performance/error handling, and media asset relationship notes
- expand walkseditor, calendar, event, and ics HLDs with required sections, integration subpoints, data flows, and performance/error handling aligned to jsonwalks depth benchmarks
- refresh architecture.md with module summaries, separation of concerns, updated diagrams, and method dependency tree derived from HLDs

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953137ac208832184def468f580c899)