### PR TITLE
Normalize Mermaid diagrams for GitHub rendering

### DIFF
--- a/accounts/HLD.md
+++ b/accounts/HLD.md
@@ -18,24 +18,24 @@ The `accounts` module manages hosted site account information, including domain 
 ```mermaid
 flowchart TB
     subgraph Accounts["Accounts Module"]
-        RAccounts[RAccounts<br/>Main class]
-        Account[RAccountsAccount<br/>Account object]
-        Logfile[RAccountsLogfile<br/>Log file handler]
+        RAccounts["RAccounts\nMain class"]
+        Account["RAccountsAccount\nAccount object"]
+        Logfile["RAccountsLogfile\nLog file handler"]
     end
 
     subgraph Data["Data Sources"]
-        JoomlaDB[Joomla Database<br/>Account table]
-        Organisation[ROrganisation<br/>Org data]
+        JoomlaDB["Joomla Database\nAccount table"]
+        Organisation["ROrganisation\nOrg data"]
     end
 
     subgraph Display["Display Layer"]
-        LeafletMap[RLeafletMap<br/>Map rendering]
-        Html[RHtml<br/>HTML formatting]
-        SqlUtils[RSqlUtils<br/>Table checks]
+        LeafletMap["RLeafletMap\nMap rendering"]
+        Html["RHtml\nHTML formatting"]
+        SqlUtils["RSqlUtils\nTable checks"]
     end
 
     subgraph Client["Client-Side"]
-        AccountsJS[accounts.js<br/>Map display]
+        AccountsJS["accounts.js\nMap display"]
     end
 
     RAccounts --> JoomlaDB
@@ -135,14 +135,14 @@ sequenceDiagram
     participant Organisation as ROrganisation
     participant Account as Account Record
 
-    RAccounts->>DB: getAccounts()
+    RAccounts->>DB: "getAccounts()"
     DB-->>RAccounts: accounts[]
-    RAccounts->>Organisation: new()
-    Organisation->>Organisation: load()
-    Organisation-->>RAccounts: areas, groups
+    RAccounts->>Organisation: "new()"
+    Organisation->>Organisation: "load()"
+    Organisation-->>RAccounts: "areas, groups"
     loop for each account
-        RAccounts->>RAccounts: updateAccount(item, org)
-        RAccounts->>DB: updateDatabaseRecord()
+        RAccounts->>RAccounts: "updateAccount(item, org)"
+        RAccounts->>DB: "updateDatabaseRecord()"
     end
 ```
 
@@ -182,11 +182,11 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    Accounts[RAccounts::addMapMarkers]
+    Accounts["RAccounts::addMapMarkers"]
     Map[RLeafletMap]
     Loader[RLoad]
-    BaseJS[/media/js<br/>ra.js, ra.map.js, ra.tabs.js]
-    AccountsJS[/media/accounts/accounts.js]
+    BaseJS["/media/js\nra.js, ra.map.js, ra.tabs.js"]
+    AccountsJS["/media/accounts/accounts.js"]
     Leaflet[Leaflet core + plugins]
 
     Accounts --> Map

--- a/accounts/HLD.md
+++ b/accounts/HLD.md
@@ -18,24 +18,24 @@ The `accounts` module manages hosted site account information, including domain 
 ```mermaid
 flowchart TB
     subgraph Accounts["Accounts Module"]
-        RAccounts["RAccounts\nMain class"]
-        Account["RAccountsAccount\nAccount object"]
-        Logfile["RAccountsLogfile\nLog file handler"]
+        RAccounts["RAccounts<br/>Main class"]
+        Account["RAccountsAccount<br/>Account object"]
+        Logfile["RAccountsLogfile<br/>Log file handler"]
     end
 
     subgraph Data["Data Sources"]
-        JoomlaDB["Joomla Database\nAccount table"]
-        Organisation["ROrganisation\nOrg data"]
+        JoomlaDB["Joomla Database<br/>Account table"]
+        Organisation["ROrganisation<br/>Org data"]
     end
 
     subgraph Display["Display Layer"]
-        LeafletMap["RLeafletMap\nMap rendering"]
-        Html["RHtml\nHTML formatting"]
-        SqlUtils["RSqlUtils\nTable checks"]
+        LeafletMap["RLeafletMap<br/>Map rendering"]
+        Html["RHtml<br/>HTML formatting"]
+        SqlUtils["RSqlUtils<br/>Table checks"]
     end
 
     subgraph Client["Client-Side"]
-        AccountsJS["accounts.js\nMap display"]
+        AccountsJS["accounts.js<br/>Map display"]
     end
 
     RAccounts --> JoomlaDB
@@ -185,7 +185,7 @@ flowchart LR
     Accounts["RAccounts::addMapMarkers"]
     Map[RLeafletMap]
     Loader[RLoad]
-    BaseJS["/media/js\nra.js, ra.map.js, ra.tabs.js"]
+    BaseJS["/media/js<br/>ra.js, ra.map.js, ra.tabs.js"]
     AccountsJS["/media/accounts/accounts.js"]
     Leaflet[Leaflet core + plugins]
 

--- a/architecture.md
+++ b/architecture.md
@@ -105,7 +105,7 @@ sequenceDiagram
     SrcWM->>Walks: "addWalk(walk)"
 
     Note over Presenter: Prepare render + assets
-    Presenter->>LeafletMap: "setCommand(\"ra.display.walksTabs\") + payload"
+    Presenter->>LeafletMap: "setCommand(ra.display.walksTabs) + payload"
     LeafletMap->>LeafletScript: "add(options + data)"
     LeafletScript->>RLoad: "addScript/addStyle (cache-busted)"
     RLoad->>Doc: enqueue assets + inline JSON
@@ -245,22 +245,22 @@ The Ramblers Library uses a three-layer architecture: **Server-Side PHP**, **Pre
 ```mermaid
 flowchart TB
     subgraph Server["Server-Side PHP Layer"]
-        Domain["Domain Models\nRJsonwalksWalk, RJsonwalksWalks"]
-        Orchestration["Orchestration\nRJsonwalksFeed, RJsonwalksStdDisplay"]
-        DataSources["Data Sources\nRJsonwalksWmFeed, RFeedhelper"]
+        Domain["Domain Models<br/>RJsonwalksWalk, RJsonwalksWalks"]
+        Orchestration["Orchestration<br/>RJsonwalksFeed, RJsonwalksStdDisplay"]
+        DataSources["Data Sources<br/>RJsonwalksWmFeed, RFeedhelper"]
     end
 
     subgraph Presentation["Presentation Layer"]
-        Display["Display Classes\nRJsonwalksStdDisplay, RLeafletMap"]
-        AssetLoad["Asset Loading\nRLoad, RLeafletScript"]
-        DataInjection["Data Injection\nJSON payloads, script declarations"]
+        Display["Display Classes<br/>RJsonwalksStdDisplay, RLeafletMap"]
+        AssetLoad["Asset Loading<br/>RLoad, RLeafletScript"]
+        DataInjection["Data Injection<br/>JSON payloads, script declarations"]
     end
 
     subgraph Client["Client-Side JavaScript Layer"]
-        Core["Core Library\nra.js, ra.map.js"]
-        DisplayJS["Display Modules\nra.display.walksTabs, ra.display.organisationMap"]
-        Maps["Map System\nra.leafletmap, L.Control.*"]
-        Vendors["Vendor Libraries\ncvList, Leaflet.js, FullCalendar"]
+        Core["Core Library<br/>ra.js, ra.map.js"]
+        DisplayJS["Display Modules<br/>ra.display.walksTabs, ra.display.organisationMap"]
+        Maps["Map System<br/>ra.leafletmap, L.Control.*"]
+        Vendors["Vendor Libraries<br/>cvList, Leaflet.js, FullCalendar"]
     end
 
     Server --> Presentation
@@ -323,22 +323,22 @@ flowchart LR
   Client["Browser / Client"] --> Joomla[Joomla Site]
 
   subgraph RL["Ramblers Library (site library)"]
-    JW["jsonwalks\nfeed + domain + presenters"]
-    LF["leaflet\nmap + script + options"]
-    GPX["gpx\nfolder stats + map feeds"]
-    EV["event + ics\ncalendar exports"]
-    ORG["organisation + accounts\norg feed + DB"]
-    UTIL["utilities\nerrors + load + geometry + html"]
+    JW["jsonwalks<br/>feed + domain + presenters"]
+    LF["leaflet<br/>map + script + options"]
+    GPX["gpx<br/>folder stats + map feeds"]
+    EV["event + ics<br/>calendar exports"]
+    ORG["organisation + accounts<br/>org feed + DB"]
+    UTIL["utilities<br/>errors + load + geometry + html"]
   end
 
   Joomla --> RL
 
-  JW --> WMAPI["Walk Manager API\nwalks / groups"]
+  JW --> WMAPI["Walk Manager API<br/>walks / groups"]
   ORG --> ORGFEED[Organisation JSON feeds]
-  JW --> Cache["(Disk cache\ncache/ra_wm_feed)"]
+  JW --> Cache["(Disk cache<br/>cache/ra_wm_feed)"]
   GPX --> GPXFS["Local GPX files/folders"]
   ORG --> DB["(Joomla DB tables)"]
-  LF --> JoomlaDoc["Joomla Document\nscripts + styles + JSON payload"]
+  LF --> JoomlaDoc["Joomla Document<br/>scripts + styles + JSON payload"]
   UTIL --> Log[Error telemetry + Joomla messages]
 ```
 **Notes**
@@ -349,8 +349,8 @@ flowchart LR
 ```mermaid
 flowchart TB
   subgraph Acquire["Data acquisition"]
-    FH["RFeedhelper\nHTTP + cache + errors"]
-    WM["RJsonwalksWmFeed\nWM client + caching"]
+    FH["RFeedhelper<br/>HTTP + cache + errors"]
+    WM["RJsonwalksWmFeed<br/>WM client + caching"]
   end
 
   subgraph Domain["Domain modelling"]
@@ -374,7 +374,7 @@ flowchart TB
   end
 
   subgraph Export["Exports"]
-    EG["event/feed.php\n(ICS aggregation entrypoint)"]
+    EG["event/feed.php<br/>(ICS aggregation entrypoint)"]
     Ics[RIcsOutput]
   end
 
@@ -635,7 +635,7 @@ flowchart LR
   FreshJSON --> CacheWrite[Write cache snapshot]
   CacheWrite --> CachedJSON
 
-  WmFeed --> OrgOpt["RJsonwalksWmOrganisation\noptional delta check"]
+  WmFeed --> OrgOpt["RJsonwalksWmOrganisation<br/>optional delta check"]
   OrgOpt --> OrgSlow{Slow or mismatch?}
   OrgSlow -- Yes --> Err[RErrors]
   OrgSlow -- No --> OK[Proceed]
@@ -836,40 +836,40 @@ RLeafletGpxMap --> RGpxStatistics
 ```mermaid
 flowchart LR
   FeedCtor["RJsonwalksFeed::__construct"] --> WalksCtor["RJsonwalksWalks::__construct"]
-  FeedCtor --> FeedFilters[RJsonwalksFeed: ":filter*()]"
-  FeedCtor --> FeedDisplay[RJsonwalksFeed: ":display]"
-  FeedDisplay --> StdDisplay[RJsonwalksStdDisplay: ":DisplayWalks]"
-  FeedDisplay --> Simple[RJsonwalksStdSimplelist: ":DisplayWalks]"
-  FeedDisplay --> Table[RJsonwalksStdWalktable: ":DisplayWalks]"
-  FeedDisplay --> Cancel[RJsonwalksStdCancelledwalks: ":DisplayWalks]"
-  StdDisplay --> MapCtor[RLeafletMap: ":__construct]"
-  StdDisplay --> MapCommand[RLeafletMap: ":setCommand]"
-  StdDisplay --> MapDisplay[RLeafletMap: ":display]"
-  MapDisplay --> LeafletAdd[RLeafletScript: ":add]"
-  LeafletAdd --> LoadAssets[RLoad: ":addScript/addStyleSheet]"
-  FeedDisplay --> MapMarker[RJsonwalksLeafletMapmarker: ":DisplayWalks]"
+  FeedCtor --> FeedFilters["RJsonwalksFeed: filter*()"]
+  FeedCtor --> FeedDisplay["RJsonwalksFeed: display"]
+  FeedDisplay --> StdDisplay["RJsonwalksStdDisplay: DisplayWalks"]
+  FeedDisplay --> Simple["RJsonwalksStdSimplelist: DisplayWalks"]
+  FeedDisplay --> Table["RJsonwalksStdWalktable: DisplayWalks"]
+  FeedDisplay --> Cancel["RJsonwalksStdCancelledwalks: DisplayWalks"]
+  StdDisplay --> MapCtor["RLeafletMap: __construct"]
+  StdDisplay --> MapCommand["RLeafletMap: setCommand"]
+  StdDisplay --> MapDisplay["RLeafletMap: display"]
+  MapDisplay --> LeafletAdd["RLeafletScript: add"]
+  LeafletAdd --> LoadAssets["RLoad: addScript/addStyleSheet"]
+  FeedDisplay --> MapMarker["RJsonwalksLeafletMapmarker: DisplayWalks"]
   MapMarker --> MapDisplay
-  FeedDisplay --> IcsDownload[RJsonwalksFeed: ":displayIcsDownload]"
-  IcsDownload --> EventGroup[REventGroup: ":addWalks]"
-  IcsDownload --> EventDownload[REventDownload: ":Display]"
-  EventGroup --> IcsOutput[RIcsOutput: ":addRecord/addSequence]"
+  FeedDisplay --> IcsDownload["RJsonwalksFeed: displayIcsDownload"]
+  IcsDownload --> EventGroup["REventGroup: addWalks"]
+  IcsDownload --> EventDownload["REventDownload: Display"]
+  EventGroup --> IcsOutput["RIcsOutput: addRecord/addSequence"]
 ```
 
 ### 11.2 Accounts + organisation + feedhelper + errors
 ```mermaid
 flowchart LR
   OrgLoad["ROrganisation::load"] --> OrgFeed["ROrganisation::readFeed"]
-  OrgFeed --> FHGet[RFeedhelper: ":getFeed]"
-  FHGet --> FHCache[RFeedhelper: ":createCachedFileFromUrl]"
-  FHGet --> FHError[RErrors: ":notifyError]"
-  OrgLoad --> OrgDisplay[ROrganisation: ":display]"
-  OrgDisplay --> MapSet[RLeafletMap: ":setDataObject]"
-  OrgDisplay --> LoadAssets[RLoad: ":addScript/addStyleSheet]"
+  OrgFeed --> FHGet["RFeedhelper: getFeed"]
+  FHGet --> FHCache["RFeedhelper: createCachedFileFromUrl"]
+  FHGet --> FHError["RErrors: notifyError"]
+  OrgLoad --> OrgDisplay["ROrganisation: display"]
+  OrgDisplay --> MapSet["RLeafletMap: setDataObject"]
+  OrgDisplay --> LoadAssets["RLoad: addScript/addStyleSheet"]
 
   AccUpdate["RAccounts::updateAccounts"] --> OrgConstruct["ROrganisation::__construct"]
-  AccUpdate --> DbUpdate[RAccounts: ":updateDatabase]"
-  DbUpdate --> SqlUtils[RSqlUtils: ":executeQuery]"
-  AccUpdate --> MapMarkers[RAccounts: ":addMapMarkers]"
+  AccUpdate --> DbUpdate["RAccounts: updateDatabase"]
+  DbUpdate --> SqlUtils["RSqlUtils: executeQuery"]
+  AccUpdate --> MapMarkers["RAccounts: addMapMarkers"]
   MapMarkers --> MapSet
 ```
 
@@ -877,14 +877,14 @@ flowchart LR
 ```mermaid
 flowchart LR
   GpxFolder["RLeafletGpxMaplist::display"] --> Stats["RGpxStatistics::buildStatistics"]
-  Stats --> GpxJson[RGpxStatistic: ":jsonSerialize]"
-  GpxFolder --> LeafletCmd[RLeafletMap: ":setCommand(\\"ra.display.gpxFolder\\")]"
-  GpxFolder --> LeafletData[RLeafletMap: ":setDataObject]"
-  LeafletData --> LeafletAdd[RLeafletScript: ":add]"
-  LeafletAdd --> LoadAssets[RLoad: ":addScript/addStyleSheet]"
+  Stats --> GpxJson["RGpxStatistic: jsonSerialize"]
+  GpxFolder --> LeafletCmd["RLeafletMap: setCommand(ra.display.gpxFolder)"]
+  GpxFolder --> LeafletData["RLeafletMap: setDataObject"]
+  LeafletData --> LeafletAdd["RLeafletScript: add"]
+  LeafletAdd --> LoadAssets
 
-  CsvList["RLeafletCsvList::display"] --> CsvCmd["RLeafletMap::setCommand("\\\"ra.display.tableList\\\"")"];
-  CsvList --> CsvData[RLeafletMap: ":setDataObject]"
+  CsvList["RLeafletCsvList::display"] --> CsvCmd["RLeafletMap::setCommand(ra.display.tableList)"]
+  CsvList --> CsvData["RLeafletMap: setDataObject"]
   CsvData --> LeafletAdd
 ```
 

--- a/architecture.md
+++ b/architecture.md
@@ -67,7 +67,7 @@ This updated sequence diagram highlights the external WM API call (per the publi
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Page as Joomla Page/Module
+    participant Page as "Joomla Page/Module"
     participant FeedOpts as RJsonwalksFeedoptions
     participant Feed as RJsonwalksFeed
     participant SrcWM as RJsonwalksSourcewalksmanager
@@ -76,43 +76,43 @@ sequenceDiagram
     participant WMFileIO as RJsonwalksWmFileio
     participant WMAPI as Walk Manager API
     participant Walks as RJsonwalksWalks
-    participant Presenter as Display (Std/BU51/etc.)
+    participant Presenter as "Display (Std/BU51/etc.)"
     participant LeafletMap as RLeafletMap
     participant LeafletScript as RLeafletScript
     participant RLoad as RLoad
     participant Doc as Joomla Document
-    participant Browser as Browser (ra.bootstrapper)
+    participant Browser as "Browser (ra.bootstrapper)"
 
     Note over Page: Construct feed options + presenter
-    Page->>FeedOpts: new('BU51') + group/date filters
-    Page->>Feed: new(FeedOpts)
-    Page->>Presenter: new(Display)
+    Page->>FeedOpts: "new('BU51') + group/date filters"
+    Page->>Feed: "new(FeedOpts)"
+    Page->>Presenter: "new(Display)"
 
     Note over Feed: Acquire data via WM API
-    Feed->>SrcWM: getWalks(Walks)
-    SrcWM->>WMFeed: getGroupFutureItems(groups,...)
-    WMFeed->>Cache: whichSource(cacheFile)
+    Feed->>SrcWM: "getWalks(Walks)"
+    SrcWM->>WMFeed: "getGroupFutureItems(groups,...)"
+    WMFeed->>Cache: "whichSource(cacheFile)"
     alt cache fresh
         Cache-->>WMFeed: cached JSON
     else read upstream
-        WMFeed->>WMFileIO: readFile(feedUrl)
-        WMFileIO->>WMAPI: GET /volunteers/walksevents
-        WMAPI-->>WMFileIO: JSON (OpenAPI schema)
+        WMFeed->>WMFileIO: "readFile(feedUrl)"
+        WMFileIO->>WMAPI: "GET /volunteers/walksevents"
+        WMAPI-->>WMFileIO: "JSON (OpenAPI schema)"
         WMFileIO-->>WMFeed: response body
-        WMFeed->>Cache: writeFile(cacheFile, body)
+        WMFeed->>Cache: "writeFile(cacheFile, body)"
     end
     WMFeed->>SrcWM: convertResults + normalise
-    SrcWM->>Walks: addWalk(walk)
+    SrcWM->>Walks: "addWalk(walk)"
 
     Note over Presenter: Prepare render + assets
-    Presenter->>LeafletMap: setCommand("ra.display.walksTabs") + payload
-    LeafletMap->>LeafletScript: add(options + data)
-    LeafletScript->>RLoad: addScript/addStyle (cache-busted)
+    Presenter->>LeafletMap: "setCommand(\"ra.display.walksTabs\") + payload"
+    LeafletMap->>LeafletScript: "add(options + data)"
+    LeafletScript->>RLoad: "addScript/addStyle (cache-busted)"
     RLoad->>Doc: enqueue assets + inline JSON
 
     Note over Doc: Deliver page
-    Doc-->>Browser: HTML + scripts/styles
-    Browser->>Browser: ra.bootstrapper() hydrates display
+    Doc-->>Browser: "HTML + scripts/styles"
+    Browser->>Browser: "ra.bootstrapper() hydrates display"
 ```
 
 **Key Points:**
@@ -245,22 +245,22 @@ The Ramblers Library uses a three-layer architecture: **Server-Side PHP**, **Pre
 ```mermaid
 flowchart TB
     subgraph Server["Server-Side PHP Layer"]
-        Domain[Domain Models<br/>RJsonwalksWalk, RJsonwalksWalks]
-        Orchestration[Orchestration<br/>RJsonwalksFeed, RJsonwalksStdDisplay]
-        DataSources[Data Sources<br/>RJsonwalksWmFeed, RFeedhelper]
+        Domain["Domain Models\nRJsonwalksWalk, RJsonwalksWalks"]
+        Orchestration["Orchestration\nRJsonwalksFeed, RJsonwalksStdDisplay"]
+        DataSources["Data Sources\nRJsonwalksWmFeed, RFeedhelper"]
     end
 
     subgraph Presentation["Presentation Layer"]
-        Display[Display Classes<br/>RJsonwalksStdDisplay, RLeafletMap]
-        AssetLoad[Asset Loading<br/>RLoad, RLeafletScript]
-        DataInjection[Data Injection<br/>JSON payloads, script declarations]
+        Display["Display Classes\nRJsonwalksStdDisplay, RLeafletMap"]
+        AssetLoad["Asset Loading\nRLoad, RLeafletScript"]
+        DataInjection["Data Injection\nJSON payloads, script declarations"]
     end
 
     subgraph Client["Client-Side JavaScript Layer"]
-        Core[Core Library<br/>ra.js, ra.map.js]
-        DisplayJS[Display Modules<br/>ra.display.walksTabs, ra.display.organisationMap]
-        Maps[Map System<br/>ra.leafletmap, L.Control.*]
-        Vendors[Vendor Libraries<br/>cvList, Leaflet.js, FullCalendar]
+        Core["Core Library\nra.js, ra.map.js"]
+        DisplayJS["Display Modules\nra.display.walksTabs, ra.display.organisationMap"]
+        Maps["Map System\nra.leafletmap, L.Control.*"]
+        Vendors["Vendor Libraries\ncvList, Leaflet.js, FullCalendar"]
     end
 
     Server --> Presentation
@@ -320,25 +320,25 @@ Customized or heavily integrated vendor libraries:
 ### 1.1 System context diagram (packages + external dependencies)
 ```mermaid
 flowchart LR
-  Client[Browser / Client] --> Joomla[Joomla Site]
+  Client["Browser / Client"] --> Joomla[Joomla Site]
 
   subgraph RL["Ramblers Library (site library)"]
-    JW[jsonwalks\nfeed + domain + presenters]
-    LF[leaflet\nmap + script + options]
-    GPX[gpx\nfolder stats + map feeds]
-    EV[event + ics\ncalendar exports]
-    ORG[organisation + accounts\norg feed + DB]
-    UTIL[utilities\nerrors + load + geometry + html]
+    JW["jsonwalks\nfeed + domain + presenters"]
+    LF["leaflet\nmap + script + options"]
+    GPX["gpx\nfolder stats + map feeds"]
+    EV["event + ics\ncalendar exports"]
+    ORG["organisation + accounts\norg feed + DB"]
+    UTIL["utilities\nerrors + load + geometry + html"]
   end
 
   Joomla --> RL
 
-  JW --> WMAPI[Walk Manager API\nwalks / groups]
+  JW --> WMAPI["Walk Manager API\nwalks / groups"]
   ORG --> ORGFEED[Organisation JSON feeds]
-  JW --> Cache[(Disk cache\ncache/ra_wm_feed)]
-  GPX --> GPXFS[Local GPX files/folders]
-  ORG --> DB[(Joomla DB tables)]
-  LF --> JoomlaDoc[Joomla Document\nscripts + styles + JSON payload]
+  JW --> Cache["(Disk cache\ncache/ra_wm_feed)"]
+  GPX --> GPXFS["Local GPX files/folders"]
+  ORG --> DB["(Joomla DB tables)"]
+  LF --> JoomlaDoc["Joomla Document\nscripts + styles + JSON payload"]
   UTIL --> Log[Error telemetry + Joomla messages]
 ```
 **Notes**
@@ -349,8 +349,8 @@ flowchart LR
 ```mermaid
 flowchart TB
   subgraph Acquire["Data acquisition"]
-    FH[RFeedhelper\nHTTP + cache + errors]
-    WM[RJsonwalksWmFeed\nWM client + caching]
+    FH["RFeedhelper\nHTTP + cache + errors"]
+    WM["RJsonwalksWmFeed\nWM client + caching"]
   end
 
   subgraph Domain["Domain modelling"]
@@ -422,38 +422,38 @@ This is the “shape” of the library: `jsonwalks` does orchestration + domain;
 ```mermaid
 sequenceDiagram
   autonumber
-  participant Joomla as Joomla Module/Page
+  participant Joomla as "Joomla Module/Page"
   participant FeedOpts as RJsonwalksFeedoptions
   participant Feed as RJsonwalksFeed
   participant WMFeed as RJsonwalksWmFeed
   participant Cache as RJsonwalksWmCachefolder
   participant WMAPI as Walk Manager API
   participant Walks as RJsonwalksWalks
-  participant Presenter as Display (Std/BU51/etc.)
+  participant Presenter as "Display (Std/BU51/etc.)"
   participant LeafletMap as RLeafletMap
   participant RLoad as RLoad
   participant Doc as Joomla Document
-  participant Browser as Browser (ra.bootstrapper)
+  participant Browser as "Browser (ra.bootstrapper)"
 
-  Joomla->>FeedOpts: configure (groups, date range, types)
-  Joomla->>Feed: new(FeedOpts)
-  Feed->>WMFeed: getGroupFutureItems(...)
-  WMFeed->>Cache: whichSource(cacheFile)
+  Joomla->>FeedOpts: "configure (groups, date range, types)"
+  Joomla->>Feed: "new(FeedOpts)"
+  Feed->>WMFeed: "getGroupFutureItems(...)"
+  WMFeed->>Cache: "whichSource(cacheFile)"
   alt cache fresh (<10 min)
     Cache-->>WMFeed: cached JSON
   else fetch upstream
-    WMFeed->>WMAPI: GET /volunteers/walksevents (OpenAPI schema)
+    WMFeed->>WMAPI: "GET /volunteers/walksevents (OpenAPI schema)"
     WMAPI-->>WMFeed: JSON payload
-    WMFeed->>Cache: writeFile(cacheFile, payload)
+    WMFeed->>Cache: "writeFile(cacheFile, payload)"
   end
   WMFeed-->>Feed: items[]
   Feed->>Walks: hydrate + filter + flags
-  Joomla->>Presenter: configure tabs/view
+  Joomla->>Presenter: "configure tabs/view"
   Presenter->>LeafletMap: setCommand + data payload
-  LeafletMap->>RLoad: add script/style assets (cache-busted)
+  LeafletMap->>RLoad: "add script/style assets (cache-busted)"
   RLoad->>Doc: enqueue assets + inline JSON payload
   Doc-->>Browser: HTML + assets
-  Browser->>Browser: ra.bootstrapper initialises modules
+  Browser->>Browser: "ra.bootstrapper initialises modules"
 ```
 
 **Highlights:** External WM API calls, cache freshness checks, and the RLoad-driven media pipeline that hands the bootstrapper JSON payloads for client-side rendering.
@@ -464,8 +464,8 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
   autonumber
-  actor Page as Joomla Page / Module
-  participant Display as Presenter (StdDisplay / Simplelist / Walktable / Cancelled / Mapmarker)
+  actor Page as "Joomla Page / Module"
+  participant Display as "Presenter (StdDisplay / Simplelist / Walktable / Cancelled / Mapmarker)"
   participant Feed as RJsonwalksFeed
   participant Walks as RJsonwalksWalks
   participant Wm as RJsonwalksWmFeed
@@ -477,7 +477,7 @@ sequenceDiagram
   participant Doc as Joomla Document
 
   Page->>Display: instantiate + configure
-  Display->>Feed: new(options)
+  Display->>Feed: "new(options)"
   Feed->>Wm: request WM data
   Wm->>Cache: check cached snapshot
   alt Cache hit
@@ -583,19 +583,19 @@ class RAccounts
 class RSqlUtils
 class RHtml
 
-RJsonwalksFeed --> RJsonwalksWalks : builds/filters
+RJsonwalksFeed --> RJsonwalksWalks : "builds/filters"
 RJsonwalksWalks "1" --> "0..*" RJsonwalksWalk : contains
 RJsonwalksFeed --> RLeafletMap : publish map payload
 RLeafletMap --> RLeafletMapoptions : owns
 RLeafletMap --> RLeafletScript : delegates injection
 RLeafletScript --> RLoad : enqueue assets
-RLeafletGpxMap --> RGpxStatistics : folder stats/elevation
+RLeafletGpxMap --> RGpxStatistics : "folder stats/elevation"
 RLeafletGpxMap --> RLeafletMap : map payload
 
-RFeedhelper --> RErrors : errors/validation
+RFeedhelper --> RErrors : "errors/validation"
 ROrganisation --> RFeedhelper : organisation feed retrieval
 RAccounts --> ROrganisation : hydrate org metadata
-RAccounts --> RSqlUtils : table checks/queries
+RAccounts --> RSqlUtils : "table checks/queries"
 RAccounts --> RHtml : render tables
 RAccounts --> RLeafletMap : hosted site markers
 ROrganisation --> RLeafletMap : area map overlays
@@ -635,7 +635,7 @@ flowchart LR
   FreshJSON --> CacheWrite[Write cache snapshot]
   CacheWrite --> CachedJSON
 
-  WmFeed --> OrgOpt[RJsonwalksWmOrganisation\noptional delta check]
+  WmFeed --> OrgOpt["RJsonwalksWmOrganisation\noptional delta check"]
   OrgOpt --> OrgSlow{Slow or mismatch?}
   OrgSlow -- Yes --> Err[RErrors]
   OrgSlow -- No --> OK[Proceed]
@@ -707,8 +707,8 @@ RJsonwalksWalks "1" --> "0..*" RJsonwalksWalk
 
 RJsonwalksWalk "1" --> "1" RJsonwalksWalkAdmin
 RJsonwalksWalk "1" --> "1" RJsonwalksWalkBasics
-RJsonwalksWalk "1" --> "0..*" RJsonwalksWalkItems : walks / meeting / start / finish / contacts
-RJsonwalksWalkItems --> RJsonwalksWalkTimelocation : time/location nodes
+RJsonwalksWalk "1" --> "0..*" RJsonwalksWalkItems : "walks / meeting / start / finish / contacts"
+RJsonwalksWalkItems --> RJsonwalksWalkTimelocation : "time/location nodes"
 RJsonwalksWalk "1" --> "0..1" RJsonwalksWalkFlags
 RJsonwalksWalk "1" --> "0..1" RJsonwalksWalkBookings
 ```
@@ -726,7 +726,7 @@ flowchart TB
   Org --> Map[RLeafletMap]
   Org --> Html[RHtml]
 
-  Org --> DB[(Joomla DB)]
+  Org --> DB["(Joomla DB)"]
   Acc[RAccounts] --> DB
   Acc --> Sql[RSqlUtils]
   Acc --> Map
@@ -835,56 +835,56 @@ RLeafletGpxMap --> RGpxStatistics
 ### 11.1 jsonwalks + leaflet + exports
 ```mermaid
 flowchart LR
-  FeedCtor[RJsonwalksFeed::__construct] --> WalksCtor[RJsonwalksWalks::__construct]
-  FeedCtor --> FeedFilters[RJsonwalksFeed::filter*()]
-  FeedCtor --> FeedDisplay[RJsonwalksFeed::display]
-  FeedDisplay --> StdDisplay[RJsonwalksStdDisplay::DisplayWalks]
-  FeedDisplay --> Simple[RJsonwalksStdSimplelist::DisplayWalks]
-  FeedDisplay --> Table[RJsonwalksStdWalktable::DisplayWalks]
-  FeedDisplay --> Cancel[RJsonwalksStdCancelledwalks::DisplayWalks]
-  StdDisplay --> MapCtor[RLeafletMap::__construct]
-  StdDisplay --> MapCommand[RLeafletMap::setCommand]
-  StdDisplay --> MapDisplay[RLeafletMap::display]
-  MapDisplay --> LeafletAdd[RLeafletScript::add]
-  LeafletAdd --> LoadAssets[RLoad::addScript/addStyleSheet]
-  FeedDisplay --> MapMarker[RJsonwalksLeafletMapmarker::DisplayWalks]
+  FeedCtor["RJsonwalksFeed::__construct"] --> WalksCtor["RJsonwalksWalks::__construct"]
+  FeedCtor --> FeedFilters[RJsonwalksFeed: ":filter*()]"
+  FeedCtor --> FeedDisplay[RJsonwalksFeed: ":display]"
+  FeedDisplay --> StdDisplay[RJsonwalksStdDisplay: ":DisplayWalks]"
+  FeedDisplay --> Simple[RJsonwalksStdSimplelist: ":DisplayWalks]"
+  FeedDisplay --> Table[RJsonwalksStdWalktable: ":DisplayWalks]"
+  FeedDisplay --> Cancel[RJsonwalksStdCancelledwalks: ":DisplayWalks]"
+  StdDisplay --> MapCtor[RLeafletMap: ":__construct]"
+  StdDisplay --> MapCommand[RLeafletMap: ":setCommand]"
+  StdDisplay --> MapDisplay[RLeafletMap: ":display]"
+  MapDisplay --> LeafletAdd[RLeafletScript: ":add]"
+  LeafletAdd --> LoadAssets[RLoad: ":addScript/addStyleSheet]"
+  FeedDisplay --> MapMarker[RJsonwalksLeafletMapmarker: ":DisplayWalks]"
   MapMarker --> MapDisplay
-  FeedDisplay --> IcsDownload[RJsonwalksFeed::displayIcsDownload]
-  IcsDownload --> EventGroup[REventGroup::addWalks]
-  IcsDownload --> EventDownload[REventDownload::Display]
-  EventGroup --> IcsOutput[RIcsOutput::addRecord/addSequence]
+  FeedDisplay --> IcsDownload[RJsonwalksFeed: ":displayIcsDownload]"
+  IcsDownload --> EventGroup[REventGroup: ":addWalks]"
+  IcsDownload --> EventDownload[REventDownload: ":Display]"
+  EventGroup --> IcsOutput[RIcsOutput: ":addRecord/addSequence]"
 ```
 
 ### 11.2 Accounts + organisation + feedhelper + errors
 ```mermaid
 flowchart LR
-  OrgLoad[ROrganisation::load] --> OrgFeed[ROrganisation::readFeed]
-  OrgFeed --> FHGet[RFeedhelper::getFeed]
-  FHGet --> FHCache[RFeedhelper::createCachedFileFromUrl]
-  FHGet --> FHError[RErrors::notifyError]
-  OrgLoad --> OrgDisplay[ROrganisation::display]
-  OrgDisplay --> MapSet[RLeafletMap::setDataObject]
-  OrgDisplay --> LoadAssets[RLoad::addScript/addStyleSheet]
+  OrgLoad["ROrganisation::load"] --> OrgFeed["ROrganisation::readFeed"]
+  OrgFeed --> FHGet[RFeedhelper: ":getFeed]"
+  FHGet --> FHCache[RFeedhelper: ":createCachedFileFromUrl]"
+  FHGet --> FHError[RErrors: ":notifyError]"
+  OrgLoad --> OrgDisplay[ROrganisation: ":display]"
+  OrgDisplay --> MapSet[RLeafletMap: ":setDataObject]"
+  OrgDisplay --> LoadAssets[RLoad: ":addScript/addStyleSheet]"
 
-  AccUpdate[RAccounts::updateAccounts] --> OrgConstruct[ROrganisation::__construct]
-  AccUpdate --> DbUpdate[RAccounts::updateDatabase]
-  DbUpdate --> SqlUtils[RSqlUtils::executeQuery]
-  AccUpdate --> MapMarkers[RAccounts::addMapMarkers]
+  AccUpdate["RAccounts::updateAccounts"] --> OrgConstruct["ROrganisation::__construct"]
+  AccUpdate --> DbUpdate[RAccounts: ":updateDatabase]"
+  DbUpdate --> SqlUtils[RSqlUtils: ":executeQuery]"
+  AccUpdate --> MapMarkers[RAccounts: ":addMapMarkers]"
   MapMarkers --> MapSet
 ```
 
 ### 11.3 GPX + data-source adapters
 ```mermaid
 flowchart LR
-  GpxFolder[RLeafletGpxMaplist::display] --> Stats[RGpxStatistics::buildStatistics]
-  Stats --> GpxJson[RGpxStatistic::jsonSerialize]
-  GpxFolder --> LeafletCmd[RLeafletMap::setCommand(\"ra.display.gpxFolder\")]
-  GpxFolder --> LeafletData[RLeafletMap::setDataObject]
-  LeafletData --> LeafletAdd[RLeafletScript::add]
-  LeafletAdd --> LoadAssets[RLoad::addScript/addStyleSheet]
+  GpxFolder["RLeafletGpxMaplist::display"] --> Stats["RGpxStatistics::buildStatistics"]
+  Stats --> GpxJson[RGpxStatistic: ":jsonSerialize]"
+  GpxFolder --> LeafletCmd[RLeafletMap: ":setCommand(\\"ra.display.gpxFolder\\")]"
+  GpxFolder --> LeafletData[RLeafletMap: ":setDataObject]"
+  LeafletData --> LeafletAdd[RLeafletScript: ":add]"
+  LeafletAdd --> LoadAssets[RLoad: ":addScript/addStyleSheet]"
 
-  CsvList[RLeafletCsvList::display] --> CsvCmd[RLeafletMap::setCommand(\"ra.display.tableList\")];
-  CsvList --> CsvData[RLeafletMap::setDataObject]
+  CsvList["RLeafletCsvList::display"] --> CsvCmd["RLeafletMap::setCommand("\\\"ra.display.tableList\\\"")"];
+  CsvList --> CsvData[RLeafletMap: ":setDataObject]"
   CsvData --> LeafletAdd
 ```
 

--- a/calendar/HLD.md
+++ b/calendar/HLD.md
@@ -15,12 +15,12 @@ The `calendar` module renders month-by-month calendars and injects per-day walk/
 
 ```mermaid
 flowchart TB
-    Adapter["REventCalendar\ncalendar.php"]
-    Calendar["RCalendar\ncalendar.php"]
-    Events["REventGroup\nevent/group.php"]
+    Adapter["REventCalendar<br/>calendar.php"]
+    Calendar["RCalendar<br/>calendar.php"]
+    Events["REventGroup<br/>event/group.php"]
     Feed[RJsonwalksFeed]
-    Toggle["ra.js toggleVisibilities\n("media/js/ra.js")"]
-    Styles["calendar.css\nramblerslibrary.css"]
+    Toggle["ra.js toggleVisibilities<br/>("media/js/ra.js")"]
+    Styles["calendar.css<br/>ramblerslibrary.css"]
 
     Adapter --> Calendar
     Adapter --> Events

--- a/calendar/HLD.md
+++ b/calendar/HLD.md
@@ -15,12 +15,12 @@ The `calendar` module renders month-by-month calendars and injects per-day walk/
 
 ```mermaid
 flowchart TB
-    Adapter[REventCalendar<br/>calendar.php]
-    Calendar[RCalendar<br/>calendar.php]
-    Events[REventGroup<br/>event/group.php]
+    Adapter["REventCalendar\ncalendar.php"]
+    Calendar["RCalendar\ncalendar.php"]
+    Events["REventGroup\nevent/group.php"]
     Feed[RJsonwalksFeed]
-    Toggle[ra.js toggleVisibilities<br/>(media/js/ra.js)]
-    Styles[calendar.css<br/>ramblerslibrary.css]
+    Toggle["ra.js toggleVisibilities\n("media/js/ra.js")"]
+    Styles["calendar.css\nramblerslibrary.css"]
 
     Adapter --> Calendar
     Adapter --> Events
@@ -56,9 +56,9 @@ sequenceDiagram
     participant Feed as RJsonwalksFeed
     participant Browser as Browser
 
-    Feed->>Events: addWalks()/addWalksArray()
-    Adapter->>Calendar: Display(events)
-    Calendar->>Events: addEvent(display, text, currentDate)
+    Feed->>Events: "addWalks()/addWalksArray()"
+    Adapter->>Calendar: "Display(events)"
+    Calendar->>Events: "addEvent(display, text, currentDate)"
     Events-->>Calendar: HTML per day
     Calendar-->>Browser: Rendered calendar with navigation
 ```

--- a/directory/HLD.md
+++ b/directory/HLD.md
@@ -13,11 +13,11 @@ The `directory` module renders simple directory listings, filtering by allowed e
 ```mermaid
 flowchart TB
     subgraph Directory["Directory Module"]
-        RDirectoryList[RDirectoryList<br/>Listing helper]
+        RDirectoryList["RDirectoryList\nListing helper"]
     end
 
-    Filesystem[(Target folder)]
-    Joomla[Joomla APIs<br/>JFactory/JText/JURI]
+    Filesystem["(Target folder)"]
+    Joomla["Joomla APIs\nJFactory/JText/JURI"]
     Output[HTML UL links]
 
     RDirectoryList --> Filesystem
@@ -42,14 +42,14 @@ sequenceDiagram
     participant Joomla
     participant Browser
 
-    Caller->>Dir: listItems(folder, sort)
+    Caller->>Dir: "listItems(folder, sort)"
     Dir->>FS: Validate folder exists
     alt missing
-        Dir->>Joomla: enqueueMessage(error)
+        Dir->>Joomla: "enqueueMessage(error)"
         Dir-->>Caller: return
     end
     Dir->>FS: scan dir + descriptions
-    Dir->>Browser: echo <ul> with links
+    Dir->>Browser: "echo <ul> with links"
 ```
 
 ## Integration Points

--- a/directory/HLD.md
+++ b/directory/HLD.md
@@ -13,11 +13,11 @@ The `directory` module renders simple directory listings, filtering by allowed e
 ```mermaid
 flowchart TB
     subgraph Directory["Directory Module"]
-        RDirectoryList["RDirectoryList\nListing helper"]
+        RDirectoryList["RDirectoryList<br/>Listing helper"]
     end
 
     Filesystem["(Target folder)"]
-    Joomla["Joomla APIs\nJFactory/JText/JURI"]
+    Joomla["Joomla APIs<br/>JFactory/JText/JURI"]
     Output[HTML UL links]
 
     RDirectoryList --> Filesystem

--- a/dns/HLD.md
+++ b/dns/HLD.md
@@ -12,9 +12,9 @@ The `dns` module resolves mail-related DNS records to help the library discover 
 
 ```mermaid
 flowchart TB
-    Dns["RDnsRecord\nResolver"]
-    DNS["dns_get_record(DNS_ALL)\nExternal DNS"]
-    Host["SSL mail host\nmail<octet>.extendcp.co.uk"]
+    Dns["RDnsRecord<br/>Resolver"]
+    DNS["dns_get_record(DNS_ALL)<br/>External DNS"]
+    Host["SSL mail host<br/>mail<octet>.extendcp.co.uk"]
 
     Dns --> DNS
     DNS --> Dns
@@ -40,7 +40,7 @@ sequenceDiagram
     Caller->>Resolver: "getSSLMailServer()"
     Resolver->>DNS: "dns_get_record(mail.domain, DNS_ALL)"
     DNS-->>Resolver: records[]
-    Resolver->>Caller: "derived host or \"\""
+    Resolver->>Caller: "derived host or empty string"
 ```
 
 ## Integration Points

--- a/dns/HLD.md
+++ b/dns/HLD.md
@@ -12,9 +12,9 @@ The `dns` module resolves mail-related DNS records to help the library discover 
 
 ```mermaid
 flowchart TB
-    Dns[RDnsRecord<br/>Resolver]
-    DNS[dns_get_record(DNS_ALL)<br/>External DNS]
-    Host[SSL mail host<br/>mail<octet>.extendcp.co.uk]
+    Dns["RDnsRecord\nResolver"]
+    DNS["dns_get_record(DNS_ALL)\nExternal DNS"]
+    Host["SSL mail host\nmail<octet>.extendcp.co.uk"]
 
     Dns --> DNS
     DNS --> Dns
@@ -36,11 +36,11 @@ sequenceDiagram
     participant Resolver as RDnsRecord
     participant DNS as dns_get_record
 
-    Caller->>Resolver: new(domain)
-    Caller->>Resolver: getSSLMailServer()
-    Resolver->>DNS: dns_get_record(mail.domain, DNS_ALL)
+    Caller->>Resolver: "new(domain)"
+    Caller->>Resolver: "getSSLMailServer()"
+    Resolver->>DNS: "dns_get_record(mail.domain, DNS_ALL)"
     DNS-->>Resolver: records[]
-    Resolver->>Caller: derived host or ""
+    Resolver->>Caller: "derived host or \"\""
 ```
 
 ## Integration Points

--- a/errors/HLD.md
+++ b/errors/HLD.md
@@ -19,13 +19,13 @@ The `errors` module provides centralized error handling and telemetry for the Ra
 ```mermaid
 flowchart TB
     subgraph Errors["Error System"]
-        RErrors["RErrors\nMain class"]
+        RErrors["RErrors<br/>Main class"]
     end
 
     subgraph Collection["Error Collection"]
-        ErrorStore["Remote Error Store\nerrors.theramblers.org.uk"]
-        JoomlaMsg["Joomla Messages\nUser notifications"]
-        Email["Email Notifications\nOptional"]
+        ErrorStore["Remote Error Store<br/>errors.theramblers.org.uk"]
+        JoomlaMsg["Joomla Messages<br/>User notifications"]
+        Email["Email Notifications<br/>Optional"]
     end
 
     subgraph Context["Error Context"]
@@ -131,7 +131,7 @@ sequenceDiagram
     loop for each property
         RErrors->>RErrors: "checkJsonProperty(result, prop)"
         alt property missing
-            RErrors->>RErrors: "notifyError(\"Missing property\")"
+            RErrors->>RErrors: "notifyError(Missing property)"
         end
     end
     RErrors-->>Module: "true/false"

--- a/errors/HLD.md
+++ b/errors/HLD.md
@@ -19,18 +19,18 @@ The `errors` module provides centralized error handling and telemetry for the Ra
 ```mermaid
 flowchart TB
     subgraph Errors["Error System"]
-        RErrors[RErrors<br/>Main class]
+        RErrors["RErrors\nMain class"]
     end
 
     subgraph Collection["Error Collection"]
-        ErrorStore[Remote Error Store<br/>errors.theramblers.org.uk]
-        JoomlaMsg[Joomla Messages<br/>User notifications]
-        Email[Email Notifications<br/>Optional]
+        ErrorStore["Remote Error Store\nerrors.theramblers.org.uk"]
+        JoomlaMsg["Joomla Messages\nUser notifications"]
+        Email["Email Notifications\nOptional"]
     end
 
     subgraph Context["Error Context"]
         Domain[Domain name]
-        Action[Action/component]
+        Action["Action/component"]
         ErrorText[Error message]
         StackTrace[Stack trace]
     end
@@ -108,13 +108,13 @@ sequenceDiagram
     participant JoomlaApp as Joomla Application
     participant User as User Browser
 
-    Module->>RErrors: notifyError(text, action, level)
-    RErrors->>URI: getInstance()
+    Module->>RErrors: "notifyError(text, action, level)"
+    RErrors->>URI: "getInstance()"
     URI-->>RErrors: domain
-    RErrors->>RErrors: debug_backtrace(5 levels)
-    RErrors->>ErrorStore: cURL POST (domain, action, error, trace)
+    RErrors->>RErrors: "debug_backtrace(5 levels)"
+    RErrors->>ErrorStore: "cURL POST (domain, action, error, trace)"
     ErrorStore-->>RErrors: HTTP status
-    RErrors->>JoomlaApp: enqueueMessage(text, level)
+    RErrors->>JoomlaApp: "enqueueMessage(text, level)"
     JoomlaApp->>User: Display message
 ```
 
@@ -126,15 +126,15 @@ sequenceDiagram
     participant RErrors as RErrors
     participant Result as JSON Result
 
-    Module->>RErrors: checkJsonFeed(feed, title, result, props)
-    RErrors->>RErrors: checkJsonProperties(result, props)
+    Module->>RErrors: "checkJsonFeed(feed, title, result, props)"
+    RErrors->>RErrors: "checkJsonProperties(result, props)"
     loop for each property
-        RErrors->>RErrors: checkJsonProperty(result, prop)
+        RErrors->>RErrors: "checkJsonProperty(result, prop)"
         alt property missing
-            RErrors->>RErrors: notifyError("Missing property")
+            RErrors->>RErrors: "notifyError(\"Missing property\")"
         end
     end
-    RErrors-->>Module: true/false
+    RErrors-->>Module: "true/false"
 ```
 
 ## Integration Points

--- a/event/HLD.md
+++ b/event/HLD.md
@@ -18,9 +18,9 @@ The `event` module aggregates walk data into event collections and provides iCal
 ```mermaid
 flowchart TB
     subgraph Event["Event Classes"]
-        EventFeed["REventFeed\nICS output"]
-        EventGroup["REventGroup\nEvent collection"]
-        EventDownload["REventDownload\nDownload link"]
+        EventFeed["REventFeed<br/>ICS output"]
+        EventGroup["REventGroup<br/>Event collection"]
+        EventDownload["REventDownload<br/>Download link"]
     end
 
     subgraph Domain["Domain Integration"]
@@ -30,12 +30,12 @@ flowchart TB
     end
 
     subgraph Export["Export Layer"]
-        IcsOutput["RIcsOutput\nRFC5545 generator"]
+        IcsOutput["RIcsOutput<br/>RFC5545 generator"]
         IcsFile[RIcsFile]
     end
 
     subgraph Client["Client Integration"]
-        LeafletScript["RLeafletScript\nregisterWalks()"]
+        LeafletScript["RLeafletScript<br/>registerWalks()"]
     end
 
     EventFeed --> IcsOutput

--- a/event/HLD.md
+++ b/event/HLD.md
@@ -18,9 +18,9 @@ The `event` module aggregates walk data into event collections and provides iCal
 ```mermaid
 flowchart TB
     subgraph Event["Event Classes"]
-        EventFeed[REventFeed<br/>ICS output]
-        EventGroup[REventGroup<br/>Event collection]
-        EventDownload[REventDownload<br/>Download link]
+        EventFeed["REventFeed\nICS output"]
+        EventGroup["REventGroup\nEvent collection"]
+        EventDownload["REventDownload\nDownload link"]
     end
 
     subgraph Domain["Domain Integration"]
@@ -30,12 +30,12 @@ flowchart TB
     end
 
     subgraph Export["Export Layer"]
-        IcsOutput[RIcsOutput<br/>RFC5545 generator]
+        IcsOutput["RIcsOutput\nRFC5545 generator"]
         IcsFile[RIcsFile]
     end
 
     subgraph Client["Client Integration"]
-        LeafletScript[RLeafletScript<br/>registerWalks()]
+        LeafletScript["RLeafletScript\nregisterWalks()"]
     end
 
     EventFeed --> IcsOutput
@@ -186,15 +186,15 @@ sequenceDiagram
     participant Walk as RJsonwalksWalk
     participant LeafletScript as RLeafletScript
 
-    Feed->>EventGroup: addWalks(Feed)
-    EventGroup->>Feed: getWalks()
+    Feed->>EventGroup: "addWalks(Feed)"
+    EventGroup->>Feed: "getWalks()"
     Feed-->>EventGroup: Walks
-    EventGroup->>Walks: allWalks()
+    EventGroup->>Walks: "allWalks()"
     Walks-->>EventGroup: walk[]
     loop for each walk
         EventGroup->>EventGroup: add to arrayofevents
     end
-    EventGroup->>LeafletScript: registerWalks(walks)
+    EventGroup->>LeafletScript: "registerWalks(walks)"
 ```
 
 ### ICS Export Flow
@@ -205,11 +205,11 @@ sequenceDiagram
     participant Walk as RJsonwalksWalk
     participant IcsOutput as RIcsOutput
 
-    EventGroup->>IcsOutput: getIcalendarFile(IcsOutput)
+    EventGroup->>IcsOutput: "getIcalendarFile(IcsOutput)"
     loop for each event
-        EventGroup->>Walk: Event_ics(IcsOutput)
-        Walk->>IcsOutput: addRecord() for each field
-        Walk->>IcsOutput: addSequence() for updates
+        EventGroup->>Walk: "Event_ics(IcsOutput)"
+        Walk->>IcsOutput: "addRecord() for each field"
+        Walk->>IcsOutput: "addSequence() for updates"
     end
     IcsOutput-->>EventGroup: ICS text
 ```

--- a/feedhelper/HLD.md
+++ b/feedhelper/HLD.md
@@ -18,20 +18,20 @@ The `feedhelper` module provides generic HTTP feed retrieval with disk-based cac
 ```mermaid
 flowchart TB
     subgraph FeedHelper["Feed Helper"]
-        RFeedhelper[RFeedhelper<br/>Main class]
+        RFeedhelper["RFeedhelper\nMain class"]
     end
 
     subgraph Cache["Cache Management"]
-        CacheFolder[Cache Folder<br/>JPATH_SITE/cache/...]
-        CacheFile[Cached Files<br/>MD5 hash names]
+        CacheFolder["Cache Folder\nJPATH_SITE/cache/..."]
+        CacheFile["Cached Files\nMD5 hash names"]
     end
 
     subgraph External["External Services"]
-        HTTPFeed[HTTP/HTTPS Feed<br/>JSON endpoint]
+        HTTPFeed["HTTP/HTTPS Feed\nJSON endpoint"]
     end
 
     subgraph Integration["Integration"]
-        Errors[RErrors<br/>Error reporting]
+        Errors["RErrors\nError reporting"]
         FileSystem[Joomla FileSystem]
     end
 
@@ -105,31 +105,31 @@ const FEEDFOPEN = 3;
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Caller as Module/Page
+    participant Caller as "Module/Page"
     participant FeedHelper as RFeedhelper
     participant Cache as Cache Folder
     participant HTTPFeed as HTTP Feed
     participant Errors as RErrors
 
-    Caller->>FeedHelper: getFeed(url, title)
-    FeedHelper->>FeedHelper: normalize URL (HTTP→HTTPS)
+    Caller->>FeedHelper: "getFeed(url, title)"
+    FeedHelper->>FeedHelper: "normalize URL (HTTP→HTTPS)"
     FeedHelper->>FeedHelper: validate protocol
     
     alt Cache hit and fresh
         FeedHelper->>Cache: read cached file
         Cache-->>FeedHelper: contents
     else Cache miss or stale
-        FeedHelper->>HTTPFeed: file_get_contents(url)
+        FeedHelper->>HTTPFeed: "file_get_contents(url)"
         alt Success
             HTTPFeed-->>FeedHelper: contents
             FeedHelper->>Cache: write cached file
         else Failure
-            HTTPFeed-->>FeedHelper: false/error
-            FeedHelper->>Errors: notifyError()
-            FeedHelper->>Cache: use stale cache (if exists)
+            HTTPFeed-->>FeedHelper: "false/error"
+            FeedHelper->>Errors: "notifyError()"
+            FeedHelper->>Cache: "use stale cache (if exists)"
         end
     end
-    FeedHelper-->>Caller: {status, contents}
+    FeedHelper-->>Caller: "{status, contents}"
 ```
 
 ## Integration Points

--- a/feedhelper/HLD.md
+++ b/feedhelper/HLD.md
@@ -18,20 +18,20 @@ The `feedhelper` module provides generic HTTP feed retrieval with disk-based cac
 ```mermaid
 flowchart TB
     subgraph FeedHelper["Feed Helper"]
-        RFeedhelper["RFeedhelper\nMain class"]
+        RFeedhelper["RFeedhelper<br/>Main class"]
     end
 
     subgraph Cache["Cache Management"]
-        CacheFolder["Cache Folder\nJPATH_SITE/cache/..."]
-        CacheFile["Cached Files\nMD5 hash names"]
+        CacheFolder["Cache Folder<br/>JPATH_SITE/cache/..."]
+        CacheFile["Cached Files<br/>MD5 hash names"]
     end
 
     subgraph External["External Services"]
-        HTTPFeed["HTTP/HTTPS Feed\nJSON endpoint"]
+        HTTPFeed["HTTP/HTTPS Feed<br/>JSON endpoint"]
     end
 
     subgraph Integration["Integration"]
-        Errors["RErrors\nError reporting"]
+        Errors["RErrors<br/>Error reporting"]
         FileSystem[Joomla FileSystem]
     end
 

--- a/geometry/HLD.md
+++ b/geometry/HLD.md
@@ -17,17 +17,17 @@ The `geometry` module provides geographic calculation utilities, primarily great
 ```mermaid
 flowchart TB
     subgraph Geometry["Geometry Module"]
-        GreatCircle[RGeometryGreatcircle<br/>Static utility class]
+        GreatCircle["RGeometryGreatcircle\nStatic utility class"]
     end
 
     subgraph Calculations["Calculations"]
-        Distance[Great Circle Distance<br/>Haversine formula]
-        Bearing[Bearing/Azimuth<br/>Angle calculation]
+        Distance["Great Circle Distance\nHaversine formula"]
+        Bearing["Bearing/Azimuth\nAngle calculation"]
     end
 
     subgraph Integration["Integration"]
-        Jsonwalks[RJsonwalksWalks<br/>Distance filtering]
-        Leaflet[Leaflet Maps<br/>Distance display]
+        Jsonwalks["RJsonwalksWalks\nDistance filtering"]
+        Leaflet["Leaflet Maps\nDistance display"]
     end
 
     GreatCircle --> Distance
@@ -83,9 +83,9 @@ sequenceDiagram
     participant GreatCircle as RGeometryGreatcircle
     participant Result as Distance Result
 
-    Caller->>GreatCircle: distance(lat1, lon1, lat2, lon2, unit)
-    GreatCircle->>GreatCircle: validateRadius(unit)
-    GreatCircle->>GreatCircle: deg2rad(coordinates)
+    Caller->>GreatCircle: "distance(lat1, lon1, lat2, lon2, unit)"
+    GreatCircle->>GreatCircle: "validateRadius(unit)"
+    GreatCircle->>GreatCircle: "deg2rad(coordinates)"
     GreatCircle->>GreatCircle: Haversine formula
     GreatCircle-->>Caller: distance in units
 ```

--- a/geometry/HLD.md
+++ b/geometry/HLD.md
@@ -17,17 +17,17 @@ The `geometry` module provides geographic calculation utilities, primarily great
 ```mermaid
 flowchart TB
     subgraph Geometry["Geometry Module"]
-        GreatCircle["RGeometryGreatcircle\nStatic utility class"]
+        GreatCircle["RGeometryGreatcircle<br/>Static utility class"]
     end
 
     subgraph Calculations["Calculations"]
-        Distance["Great Circle Distance\nHaversine formula"]
-        Bearing["Bearing/Azimuth\nAngle calculation"]
+        Distance["Great Circle Distance<br/>Haversine formula"]
+        Bearing["Bearing/Azimuth<br/>Angle calculation"]
     end
 
     subgraph Integration["Integration"]
-        Jsonwalks["RJsonwalksWalks\nDistance filtering"]
-        Leaflet["Leaflet Maps\nDistance display"]
+        Jsonwalks["RJsonwalksWalks<br/>Distance filtering"]
+        Leaflet["Leaflet Maps<br/>Distance display"]
     end
 
     GreatCircle --> Distance

--- a/gpx/HLD.md
+++ b/gpx/HLD.md
@@ -17,20 +17,20 @@ The `gpx` module provides GPX file processing utilities including file reading, 
 ```mermaid
 flowchart TB
     subgraph Parsing["Per-file Parsing"]
-        File[RGpxFile<br/>GPX reader]
+        File["RGpxFile\nGPX reader"]
     end
 
     subgraph Stats["Statistics"]
-        Stat[RGpxStatistic<br/>Value object]
-        Stats[RGpxStatistics<br/>Folder aggregator]
+        Stat["RGpxStatistic\nValue object"]
+        Stats["RGpxStatistics\nFolder aggregator"]
     end
 
     subgraph Persistence["Persistence"]
-        Jsonlog[RGpxJsonlog<br/>JSON writer]
-        Cache[0000gpx_statistics_file.json<br/>Cache file]
+        Jsonlog["RGpxJsonlog\nJSON writer"]
+        Cache["0000gpx_statistics_file.json\nCache file"]
     end
 
-    Filesystem[(GPX folder)]
+    Filesystem["(GPX folder)"]
 
     Filesystem --> File
     File --> Stat
@@ -79,20 +79,20 @@ sequenceDiagram
     participant Parser as RGpxFile
     participant Json as RGpxJsonlog
 
-    Caller->>Stats: new(folder, getMetaFromGPX)
-    Stats->>FS: latestFile()
+    Caller->>Stats: "new(folder, getMetaFromGPX)"
+    Stats->>FS: "latestFile()"
     alt Cache stale or missing
-        Stats->>Json: new(JSONFILE)
-        Stats->>FS: processFolder()
+        Stats->>Json: "new(JSONFILE)"
+        Stats->>FS: "processFolder()"
         loop for each .gpx file
-            Stats->>Parser: new RGpxFile(path)
-            Parser-->>Stats: metadata + tracks/routes
+            Stats->>Parser: "new RGpxFile(path)"
+            Parser-->>Stats: "metadata + tracks/routes"
             Stats->>Stats: build RGpxStatistic
-            Stats->>Json: addItem(id, stat)
+            Stats->>Json: "addItem(id, stat)"
         end
-        Stats->>Json: writeFile()
+        Stats->>Json: "writeFile()"
     end
-    Caller->>Stats: getJson()
+    Caller->>Stats: "getJson()"
     Stats-->>Caller: JSON string
 ```
 

--- a/gpx/HLD.md
+++ b/gpx/HLD.md
@@ -17,17 +17,17 @@ The `gpx` module provides GPX file processing utilities including file reading, 
 ```mermaid
 flowchart TB
     subgraph Parsing["Per-file Parsing"]
-        File["RGpxFile\nGPX reader"]
+        File["RGpxFile<br/>GPX reader"]
     end
 
     subgraph Stats["Statistics"]
-        Stat["RGpxStatistic\nValue object"]
-        Stats["RGpxStatistics\nFolder aggregator"]
+        Stat["RGpxStatistic<br/>Value object"]
+        Stats["RGpxStatistics<br/>Folder aggregator"]
     end
 
     subgraph Persistence["Persistence"]
-        Jsonlog["RGpxJsonlog\nJSON writer"]
-        Cache["0000gpx_statistics_file.json\nCache file"]
+        Jsonlog["RGpxJsonlog<br/>JSON writer"]
+        Cache["0000gpx_statistics_file.json<br/>Cache file"]
     end
 
     Filesystem["(GPX folder)"]

--- a/gpxsymbols/HLD.md
+++ b/gpxsymbols/HLD.md
@@ -13,13 +13,13 @@ The `gpxsymbols` module renders available GPX waypoint symbols within Joomla vie
 ```mermaid
 flowchart TB
     subgraph Server[Server-Side]
-        Display[RGpxsymbolsDisplay<br/>display.php]
-        Exists[media/gpxsymbols/exists.php<br/>Asset check]
+        Display["RGpxsymbolsDisplay\ndisplay.php"]
+        Exists["media/gpxsymbols/exists.php\nAsset check"]
     end
 
-    subgraph Assets[Symbol Assets (/media/gpxsymbols)]
-        CSS[display.css<br/>Styles]
-        Symbols[letter/, number/, office/, transport/]
+    subgraph Assets["Symbol Assets (/media/gpxsymbols)"]
+        CSS["display.css\nStyles"]
+        Symbols["letter/, number/, office/, transport/"]
     end
 
     subgraph Client[Client Browser]
@@ -78,13 +78,13 @@ sequenceDiagram
     participant FS as File System
     participant Browser as Browser
 
-    Caller->>Display: new()
-    Display->>Doc: addStyleSheet(/media/lib_ramblers/gpxsymbols/display.css)
-    Caller->>Display: listFolder(media/.../gpxsymbols/letter)
-    Display->>FS: opendir()/readdir()
+    Caller->>Display: "new()"
+    Display->>Doc: "addStyleSheet(/media/lib_ramblers/gpxsymbols/display.css)"
+    Caller->>Display: "listFolder(media/.../gpxsymbols/letter)"
+    Display->>FS: "opendir()/readdir()"
     FS-->>Display: filenames
     loop each symbol
-        Display->>Browser: <img src=".../symbol.png">
+        Display->>Browser: "<img src=\".../symbol.png\">"
     end
 ```
 
@@ -101,8 +101,8 @@ sequenceDiagram
 ```mermaid
 flowchart LR
     Display[RGpxsymbolsDisplay]
-    Loader[JDocument::addStyleSheet]
-    Assets[/media/gpxsymbols<br/>display.css + symbol sprites]
+    Loader["JDocument::addStyleSheet"]
+    Assets["/media/gpxsymbols\ndisplay.css + symbol sprites"]
     Grid[Rendered symbol grid]
 
     Display --> Loader

--- a/gpxsymbols/HLD.md
+++ b/gpxsymbols/HLD.md
@@ -13,12 +13,12 @@ The `gpxsymbols` module renders available GPX waypoint symbols within Joomla vie
 ```mermaid
 flowchart TB
     subgraph Server[Server-Side]
-        Display["RGpxsymbolsDisplay\ndisplay.php"]
-        Exists["media/gpxsymbols/exists.php\nAsset check"]
+        Display["RGpxsymbolsDisplay<br/>display.php"]
+        Exists["media/gpxsymbols/exists.php<br/>Asset check"]
     end
 
     subgraph Assets["Symbol Assets (/media/gpxsymbols)"]
-        CSS["display.css\nStyles"]
+        CSS["display.css<br/>Styles"]
         Symbols["letter/, number/, office/, transport/"]
     end
 
@@ -84,7 +84,7 @@ sequenceDiagram
     Display->>FS: "opendir()/readdir()"
     FS-->>Display: filenames
     loop each symbol
-        Display->>Browser: "<img src=\".../symbol.png\">"
+        Display->>Browser: "<img src=/media/.../symbol.png>"
     end
 ```
 
@@ -102,7 +102,7 @@ sequenceDiagram
 flowchart LR
     Display[RGpxsymbolsDisplay]
     Loader["JDocument::addStyleSheet"]
-    Assets["/media/gpxsymbols\ndisplay.css + symbol sprites"]
+    Assets["/media/gpxsymbols<br/>display.css + symbol sprites"]
     Grid[Rendered symbol grid]
 
     Display --> Loader

--- a/html/HLD.md
+++ b/html/HLD.md
@@ -18,19 +18,19 @@ The `html` module provides HTML formatting and text conversion utilities. It han
 ```mermaid
 flowchart TB
     subgraph Html["HTML Module"]
-        RHtml["RHtml\nStatic utility class"]
+        RHtml["RHtml<br/>Static utility class"]
     end
 
     subgraph Functions["Functions"]
-        ConvertText["convertToText\nHTML → text"]
-        RemoveTags["removeNonBasicTags\nStrip tags"]
-        ConvertMails["convert_mails\nEmail obfuscation"]
-        FetchMails["fetch_mails\nEmail extraction"]
+        ConvertText["convertToText<br/>HTML → text"]
+        RemoveTags["removeNonBasicTags<br/>Strip tags"]
+        ConvertMails["convert_mails<br/>Email obfuscation"]
+        FetchMails["fetch_mails<br/>Email extraction"]
     end
 
     subgraph Integration["Integration"]
-        Accounts["RAccounts\nHTML rendering"]
-        Other["Other modules\nText processing"]
+        Accounts["RAccounts<br/>HTML rendering"]
+        Other["Other modules<br/>Text processing"]
     end
 
     RHtml --> ConvertText

--- a/html/HLD.md
+++ b/html/HLD.md
@@ -18,19 +18,19 @@ The `html` module provides HTML formatting and text conversion utilities. It han
 ```mermaid
 flowchart TB
     subgraph Html["HTML Module"]
-        RHtml[RHtml<br/>Static utility class]
+        RHtml["RHtml\nStatic utility class"]
     end
 
     subgraph Functions["Functions"]
-        ConvertText[convertToText<br/>HTML → text]
-        RemoveTags[removeNonBasicTags<br/>Strip tags]
-        ConvertMails[convert_mails<br/>Email obfuscation]
-        FetchMails[fetch_mails<br/>Email extraction]
+        ConvertText["convertToText\nHTML → text"]
+        RemoveTags["removeNonBasicTags\nStrip tags"]
+        ConvertMails["convert_mails\nEmail obfuscation"]
+        FetchMails["fetch_mails\nEmail extraction"]
     end
 
     subgraph Integration["Integration"]
-        Accounts[RAccounts<br/>HTML rendering]
-        Other[Other modules<br/>Text processing]
+        Accounts["RAccounts\nHTML rendering"]
+        Other["Other modules\nText processing"]
     end
 
     RHtml --> ConvertText
@@ -112,12 +112,12 @@ sequenceDiagram
     participant HTML as HTML String
     participant Text as Plain Text
 
-    Caller->>RHtml: convertToText(html)
+    Caller->>RHtml: "convertToText(html)"
     RHtml->>HTML: Replace line breaks
     RHtml->>HTML: Remove &nbsp;
-    RHtml->>HTML: strip_tags()
-    RHtml->>HTML: htmlspecialchars_decode()
-    RHtml->>HTML: trim()
+    RHtml->>HTML: "strip_tags()"
+    RHtml->>HTML: "htmlspecialchars_decode()"
+    RHtml->>HTML: "trim()"
     RHtml-->>Caller: Plain text
 ```
 

--- a/ics/HLD.md
+++ b/ics/HLD.md
@@ -18,21 +18,21 @@ The `ics` module provides iCalendar (RFC5545) format generation for calendar exp
 ```mermaid
 flowchart TB
     subgraph Ics["ICS Module"]
-        IcsOutput["RIcsOutput\nICS generator"]
-        IcsFile["RIcsFile\nFile handler"]
+        IcsOutput["RIcsOutput<br/>ICS generator"]
+        IcsFile["RIcsFile<br/>File handler"]
     end
 
     subgraph Functions["Functions"]
-        AddRecord["addRecord\nAdd ICS field"]
-        EscapeString["escapeString\nEscape special chars"]
-        AddSequence["addSequence\nUpdate sequence"]
-        ChunkSplit["chunk_split_unicode\nLine wrapping"]
+        AddRecord["addRecord<br/>Add ICS field"]
+        EscapeString["escapeString<br/>Escape special chars"]
+        AddSequence["addSequence<br/>Update sequence"]
+        ChunkSplit["chunk_split_unicode<br/>Line wrapping"]
     end
 
     subgraph Integration["Integration"]
-        EventFeed["REventFeed\nEvent export"]
-        EventGroup["REventGroup\nEvent collection"]
-        Walk["RJsonwalksWalk\nEvent_ics() method"]
+        EventFeed["REventFeed<br/>Event export"]
+        EventGroup["REventGroup<br/>Event collection"]
+        Walk["RJsonwalksWalk<br/>Event_ics() method"]
     end
 
     IcsOutput --> AddRecord
@@ -129,9 +129,9 @@ sequenceDiagram
     EventGroup->>IcsOutput: "new()"
     IcsOutput->>IcsOutput: "addHeader()"
     EventGroup->>Walk: "Event_ics(IcsOutput)"
-    Walk->>IcsOutput: "addRecord(\"DTSTART:\", date)"
-    Walk->>IcsOutput: "addRecord(\"SUMMARY:\", title)"
-    Walk->>IcsOutput: "addRecord(\"DESCRIPTION:\", desc)"
+    Walk->>IcsOutput: "addRecord(DTSTART:, date)"
+    Walk->>IcsOutput: "addRecord(SUMMARY:, title)"
+    Walk->>IcsOutput: "addRecord(DESCRIPTION:, desc)"
     Walk->>IcsOutput: "addSequence(updated)"
     IcsOutput->>IcsOutput: "escapeString()"
     IcsOutput->>IcsOutput: "chunk_split_unicode()"
@@ -250,4 +250,3 @@ $escaped = RIcsOutput::escapeString($text);
 ### Standards
 - **RFC5545**: iCalendar specification
 - **RFC7986**: iCalendar extensions
-

--- a/ics/HLD.md
+++ b/ics/HLD.md
@@ -18,21 +18,21 @@ The `ics` module provides iCalendar (RFC5545) format generation for calendar exp
 ```mermaid
 flowchart TB
     subgraph Ics["ICS Module"]
-        IcsOutput[RIcsOutput<br/>ICS generator]
-        IcsFile[RIcsFile<br/>File handler]
+        IcsOutput["RIcsOutput\nICS generator"]
+        IcsFile["RIcsFile\nFile handler"]
     end
 
     subgraph Functions["Functions"]
-        AddRecord[addRecord<br/>Add ICS field]
-        EscapeString[escapeString<br/>Escape special chars]
-        AddSequence[addSequence<br/>Update sequence]
-        ChunkSplit[chunk_split_unicode<br/>Line wrapping]
+        AddRecord["addRecord\nAdd ICS field"]
+        EscapeString["escapeString\nEscape special chars"]
+        AddSequence["addSequence\nUpdate sequence"]
+        ChunkSplit["chunk_split_unicode\nLine wrapping"]
     end
 
     subgraph Integration["Integration"]
-        EventFeed[REventFeed<br/>Event export]
-        EventGroup[REventGroup<br/>Event collection]
-        Walk[RJsonwalksWalk<br/>Event_ics() method]
+        EventFeed["REventFeed\nEvent export"]
+        EventGroup["REventGroup\nEvent collection"]
+        Walk["RJsonwalksWalk\nEvent_ics() method"]
     end
 
     IcsOutput --> AddRecord
@@ -126,16 +126,16 @@ sequenceDiagram
     participant IcsOutput as RIcsOutput
     participant IcsText as ICS Text
 
-    EventGroup->>IcsOutput: new()
-    IcsOutput->>IcsOutput: addHeader()
-    EventGroup->>Walk: Event_ics(IcsOutput)
-    Walk->>IcsOutput: addRecord("DTSTART:", date)
-    Walk->>IcsOutput: addRecord("SUMMARY:", title)
-    Walk->>IcsOutput: addRecord("DESCRIPTION:", desc)
-    Walk->>IcsOutput: addSequence(updated)
-    IcsOutput->>IcsOutput: escapeString()
-    IcsOutput->>IcsOutput: chunk_split_unicode()
-    EventGroup->>IcsOutput: text()
+    EventGroup->>IcsOutput: "new()"
+    IcsOutput->>IcsOutput: "addHeader()"
+    EventGroup->>Walk: "Event_ics(IcsOutput)"
+    Walk->>IcsOutput: "addRecord(\"DTSTART:\", date)"
+    Walk->>IcsOutput: "addRecord(\"SUMMARY:\", title)"
+    Walk->>IcsOutput: "addRecord(\"DESCRIPTION:\", desc)"
+    Walk->>IcsOutput: "addSequence(updated)"
+    IcsOutput->>IcsOutput: "escapeString()"
+    IcsOutput->>IcsOutput: "chunk_split_unicode()"
+    EventGroup->>IcsOutput: "text()"
     IcsOutput-->>EventGroup: Complete ICS text
 ```
 

--- a/jsonwalks/HLD.md
+++ b/jsonwalks/HLD.md
@@ -18,19 +18,19 @@ The `jsonwalks` module is the core orchestration layer for walk data management 
 ```mermaid
 flowchart TB
     subgraph Sources["Data Sources"]
-        WM["RJsonwalksSourcewalksmanager\nWalk Manager"]
-        WMArea["RJsonwalksSourcewalksmanagerarea\nArea-based WM"]
-        Editor["RJsonwalksSourcewalkseditor\nLocal editor"]
+        WM["RJsonwalksSourcewalksmanager<br/>Walk Manager"]
+        WMArea["RJsonwalksSourcewalksmanagerarea<br/>Area-based WM"]
+        Editor["RJsonwalksSourcewalkseditor<br/>Local editor"]
     end
 
     subgraph Core["Core Orchestration"]
-        Feed["RJsonwalksFeed\nMain orchestrator"]
-        FeedOpts["RJsonwalksFeedoptions\nConfiguration"]
-        Walks["RJsonwalksWalks\nCollection manager"]
+        Feed["RJsonwalksFeed<br/>Main orchestrator"]
+        FeedOpts["RJsonwalksFeedoptions<br/>Configuration"]
+        Walks["RJsonwalksWalks<br/>Collection manager"]
     end
 
     subgraph Domain["Domain Model"]
-        Walk["RJsonwalksWalk\nIndividual walk"]
+        Walk["RJsonwalksWalk<br/>Individual walk"]
         Admin[RJsonwalksWalkAdmin]
         Basics[RJsonwalksWalkBasics]
         Items[RJsonwalksWalkItems]
@@ -40,7 +40,7 @@ flowchart TB
     end
 
     subgraph Display["Display Layer"]
-        Base["RJsonwalksDisplaybase\nAbstract base"]
+        Base["RJsonwalksDisplaybase<br/>Abstract base"]
         Std[RJsonwalksStdDisplay]
         Simple[RJsonwalksStdSimplelist]
         Table[RJsonwalksStdWalktable]
@@ -49,7 +49,7 @@ flowchart TB
     end
 
     subgraph Integration["External Integration"]
-        Leaflet["RLeafletMap\nRLeafletScript"]
+        Leaflet["RLeafletMap<br/>RLeafletScript"]
         Load[RLoad]
         Errors[RErrors]
     end
@@ -328,11 +328,11 @@ sequenceDiagram
 ```mermaid
 flowchart LR
     Feed[RJsonwalksFeed]
-    DisplayClasses["RJsonwalksStdDisplay\nRJsonwalksStdSimplelist\nRJsonwalksStdWalktable"]
+    DisplayClasses["RJsonwalksStdDisplay<br/>RJsonwalksStdSimplelist<br/>RJsonwalksStdWalktable"]
     LeafletMarker[RJsonwalksLeafletMapmarker]
     Loader[RLoad]
     Leaflet[RLeafletScript]
-    BaseJS["media/js\nra.js\nra.walk.js\nra.tabs.js\nra.paginatedDataList.js\nra.feedhandler.js"]
+    BaseJS["media/js<br/>ra.js<br/>ra.walk.js<br/>ra.tabs.js<br/>ra.paginatedDataList.js<br/>ra.feedhandler.js"]
     StdJS["media/jsonwalks/std/display.js"]
     Sr02JS["media/jsonwalks/sr02/display.js"]
     BuCss["media/jsonwalks/bu51/bu51style.css"]

--- a/jsonwalks/HLD.md
+++ b/jsonwalks/HLD.md
@@ -18,19 +18,19 @@ The `jsonwalks` module is the core orchestration layer for walk data management 
 ```mermaid
 flowchart TB
     subgraph Sources["Data Sources"]
-        WM[RJsonwalksSourcewalksmanager<br/>Walk Manager]
-        WMArea[RJsonwalksSourcewalksmanagerarea<br/>Area-based WM]
-        Editor[RJsonwalksSourcewalkseditor<br/>Local editor]
+        WM["RJsonwalksSourcewalksmanager\nWalk Manager"]
+        WMArea["RJsonwalksSourcewalksmanagerarea\nArea-based WM"]
+        Editor["RJsonwalksSourcewalkseditor\nLocal editor"]
     end
 
     subgraph Core["Core Orchestration"]
-        Feed[RJsonwalksFeed<br/>Main orchestrator]
-        FeedOpts[RJsonwalksFeedoptions<br/>Configuration]
-        Walks[RJsonwalksWalks<br/>Collection manager]
+        Feed["RJsonwalksFeed\nMain orchestrator"]
+        FeedOpts["RJsonwalksFeedoptions\nConfiguration"]
+        Walks["RJsonwalksWalks\nCollection manager"]
     end
 
     subgraph Domain["Domain Model"]
-        Walk[RJsonwalksWalk<br/>Individual walk]
+        Walk["RJsonwalksWalk\nIndividual walk"]
         Admin[RJsonwalksWalkAdmin]
         Basics[RJsonwalksWalkBasics]
         Items[RJsonwalksWalkItems]
@@ -40,7 +40,7 @@ flowchart TB
     end
 
     subgraph Display["Display Layer"]
-        Base[RJsonwalksDisplaybase<br/>Abstract base]
+        Base["RJsonwalksDisplaybase\nAbstract base"]
         Std[RJsonwalksStdDisplay]
         Simple[RJsonwalksStdSimplelist]
         Table[RJsonwalksStdWalktable]
@@ -49,7 +49,7 @@ flowchart TB
     end
 
     subgraph Integration["External Integration"]
-        Leaflet[RLeafletMap<br/>RLeafletScript]
+        Leaflet["RLeafletMap\nRLeafletScript"]
         Load[RLoad]
         Errors[RErrors]
     end
@@ -243,32 +243,32 @@ public function getWalkValue($option)
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Caller as Joomla Module/Page
+    participant Caller as "Joomla Module/Page"
     participant FeedOpts as RJsonwalksFeedoptions
     participant Feed as RJsonwalksFeed
     participant Source as RJsonwalksSourcewalksmanager
     participant Walks as RJsonwalksWalks
     participant Walk as RJsonwalksWalk
     participant Display as RJsonwalksDisplaybase subclass
-    participant Leaflet as RLeafletMap/Script
+    participant Leaflet as "RLeafletMap/Script"
 
-    Caller->>FeedOpts: new('BU51') or new(options)
-    FeedOpts->>Source: getWalks(Walks)
-    Source->>Walks: addWalk(walk) for each item
+    Caller->>FeedOpts: "new('BU51') or new(options)"
+    FeedOpts->>Source: "getWalks(Walks)"
+    Source->>Walks: "addWalk(walk) for each item"
     
-    Caller->>Feed: new(FeedOpts)
-    Feed->>Walks: setNewWalks(7)
-    Feed->>Walks: setBookings()
+    Caller->>Feed: "new(FeedOpts)"
+    Feed->>Walks: "setNewWalks(7)"
+    Feed->>Walks: "setBookings()"
     
-    Caller->>Feed: filter*() methods (optional)
-    Feed->>Walks: filter*() methods
+    Caller->>Feed: "filter*() methods (optional)"
+    Feed->>Walks: "filter*() methods"
     
-    Caller->>Display: new() + configure
-    Caller->>Feed: display(Display)
-    Feed->>Display: DisplayWalks(Walks)
-    Display->>Walks: allWalks()
-    Display->>Walk: getWalkValue(), Event*() methods
-    Display->>Leaflet: setCommand(), setDataObject()
+    Caller->>Display: "new() + configure"
+    Caller->>Feed: "display(Display)"
+    Feed->>Display: "DisplayWalks(Walks)"
+    Display->>Walks: "allWalks()"
+    Display->>Walk: "getWalkValue(), Event*() methods"
+    Display->>Leaflet: "setCommand(), setDataObject()"
     Display-->>Caller: HTML output
 ```
 
@@ -280,13 +280,13 @@ sequenceDiagram
     participant Walks as RJsonwalksWalks
     participant Walk as RJsonwalksWalk
 
-    Feed->>Walks: filterGroups(['BU51', 'DE01'])
-    Walks->>Walk: notInGroup(groups) for each
-    Walk-->>Walks: true/false
+    Feed->>Walks: "filterGroups(['BU51', 'DE01'])"
+    Walks->>Walk: "notInGroup(groups) for each"
+    Walk-->>Walks: "true/false"
     Walks->>Walks: remove non-matching walks
     
-    Feed->>Walks: filterDistanceFromLatLong(lat, lon, km)
-    Walks->>Walk: distanceFromLatLong(lat, lon) for each
+    Feed->>Walks: "filterDistanceFromLatLong(lat, lon, km)"
+    Walks->>Walk: "distanceFromLatLong(lat, lon) for each"
     Walk-->>Walks: distance in km
     Walks->>Walks: remove walks beyond threshold
 ```
@@ -328,16 +328,16 @@ sequenceDiagram
 ```mermaid
 flowchart LR
     Feed[RJsonwalksFeed]
-    DisplayClasses[RJsonwalksStdDisplay<br/>RJsonwalksStdSimplelist<br/>RJsonwalksStdWalktable]
+    DisplayClasses["RJsonwalksStdDisplay\nRJsonwalksStdSimplelist\nRJsonwalksStdWalktable"]
     LeafletMarker[RJsonwalksLeafletMapmarker]
     Loader[RLoad]
     Leaflet[RLeafletScript]
-    BaseJS[media/js<br/>ra.js<br/>ra.walk.js<br/>ra.tabs.js<br/>ra.paginatedDataList.js<br/>ra.feedhandler.js]
-    StdJS[media/jsonwalks/std/display.js]
-    Sr02JS[media/jsonwalks/sr02/display.js]
-    BuCss[media/jsonwalks/bu51/bu51style.css]
-    MlJS[media/jsonwalks/ml/script.js]
-    MapJS[media/jsonwalks/leaflet/mapmarker.js]
+    BaseJS["media/js\nra.js\nra.walk.js\nra.tabs.js\nra.paginatedDataList.js\nra.feedhandler.js"]
+    StdJS["media/jsonwalks/std/display.js"]
+    Sr02JS["media/jsonwalks/sr02/display.js"]
+    BuCss["media/jsonwalks/bu51/bu51style.css"]
+    MlJS["media/jsonwalks/ml/script.js"]
+    MapJS["media/jsonwalks/leaflet/mapmarker.js"]
 
     Feed --> DisplayClasses
     DisplayClasses --> Loader

--- a/jsonwalks/leaflet/HLD.md
+++ b/jsonwalks/leaflet/HLD.md
@@ -17,16 +17,16 @@ The `jsonwalks/leaflet` module provides Leaflet map marker display for walk coll
 ```mermaid
 flowchart TB
     subgraph Display["Display Layer"]
-        MapMarker[RJsonwalksLeafletMapmarker<br/>Extends Displaybase]
+        MapMarker["RJsonwalksLeafletMapmarker\nExtends Displaybase"]
     end
 
     subgraph Integration["Integration"]
-        LeafletMap[RLeafletMap<br/>Map container]
-        Walks[RJsonwalksWalks<br/>Walk collection]
+        LeafletMap["RLeafletMap\nMap container"]
+        Walks["RJsonwalksWalks\nWalk collection"]
     end
 
     subgraph Client["Client-Side"]
-        MapMarkerJS[mapmarker.js<br/>Marker rendering]
+        MapMarkerJS["mapmarker.js\nMarker rendering"]
     end
 
     MapMarker --> LeafletMap
@@ -77,16 +77,16 @@ sequenceDiagram
     participant Script as RLeafletScript
     participant Load as RLoad
     participant Browser as Browser
-    participant ClientJS as mapmarker.js
+    participant ClientJS as "mapmarker.js"
 
-    Feed->>Mapmarker: display(Mapmarker)
-    Mapmarker->>Map: setCommand("ra.display.walksMap") + map options
-    Mapmarker->>Map: setDataObject(walks as JSON)
-    Mapmarker->>Map: display()
-    Map->>Script: add(options)
-    Script->>Load: enqueue Leaflet + /media/js + mapmarker.js
-    Load->>Browser: inject scripts/styles with cache-busting
-    Browser->>ClientJS: ra.display.walksMap(data)
+    Feed->>Mapmarker: "display(Mapmarker)"
+    Mapmarker->>Map: "setCommand(\"ra.display.walksMap\") + map options"
+    Mapmarker->>Map: "setDataObject(walks as JSON)"
+    Mapmarker->>Map: "display()"
+    Map->>Script: "add(options)"
+    Script->>Load: "enqueue Leaflet + /media/js + mapmarker.js"
+    Load->>Browser: "inject scripts/styles with cache-busting"
+    Browser->>ClientJS: "ra.display.walksMap(data)"
     ClientJS-->>Browser: render markers + popups
 ```
 

--- a/jsonwalks/leaflet/HLD.md
+++ b/jsonwalks/leaflet/HLD.md
@@ -17,16 +17,16 @@ The `jsonwalks/leaflet` module provides Leaflet map marker display for walk coll
 ```mermaid
 flowchart TB
     subgraph Display["Display Layer"]
-        MapMarker["RJsonwalksLeafletMapmarker\nExtends Displaybase"]
+        MapMarker["RJsonwalksLeafletMapmarker<br/>Extends Displaybase"]
     end
 
     subgraph Integration["Integration"]
-        LeafletMap["RLeafletMap\nMap container"]
-        Walks["RJsonwalksWalks\nWalk collection"]
+        LeafletMap["RLeafletMap<br/>Map container"]
+        Walks["RJsonwalksWalks<br/>Walk collection"]
     end
 
     subgraph Client["Client-Side"]
-        MapMarkerJS["mapmarker.js\nMarker rendering"]
+        MapMarkerJS["mapmarker.js<br/>Marker rendering"]
     end
 
     MapMarker --> LeafletMap
@@ -80,7 +80,7 @@ sequenceDiagram
     participant ClientJS as "mapmarker.js"
 
     Feed->>Mapmarker: "display(Mapmarker)"
-    Mapmarker->>Map: "setCommand(\"ra.display.walksMap\") + map options"
+    Mapmarker->>Map: "setCommand(ra.display.walksMap) + map options"
     Mapmarker->>Map: "setDataObject(walks as JSON)"
     Mapmarker->>Map: "display()"
     Map->>Script: "add(options)"
@@ -165,4 +165,3 @@ $feed->display($display);
 
 ### Related Media Files
 - `media/jsonwalks/leaflet/mapmarker.js` - Client-side marker rendering
-

--- a/jsonwalks/std/HLD.md
+++ b/jsonwalks/std/HLD.md
@@ -18,14 +18,14 @@ The `jsonwalks/std` module provides standard display implementations for renderi
 ```mermaid
 flowchart TB
     subgraph Base["Base Class"]
-        DisplayBase[RJsonwalksDisplaybase<br/>Abstract base]
+        DisplayBase["RJsonwalksDisplaybase\nAbstract base"]
     end
 
     subgraph StdDisplays["Standard Display Classes"]
-        StdDisplay[RJsonwalksStdDisplay<br/>Tabbed interface]
-        SimpleList[RJsonwalksStdSimplelist<br/>Simple list]
-        WalkTable[RJsonwalksStdWalktable<br/>Table format]
-        Cancelled[RJsonwalksStdCancelledwalks<br/>Cancelled walks]
+        StdDisplay["RJsonwalksStdDisplay\nTabbed interface"]
+        SimpleList["RJsonwalksStdSimplelist\nSimple list"]
+        WalkTable["RJsonwalksStdWalktable\nTable format"]
+        Cancelled["RJsonwalksStdCancelledwalks\nCancelled walks"]
     end
 
     subgraph Integration["Integration Layer"]
@@ -36,9 +36,9 @@ flowchart TB
     end
 
     subgraph Client["Client-Side"]
-        DisplayJS[display.js<br/>Tab management]
-        TabsJS[ra.tabs.js<br/>Tab functionality]
-        CvListJS[cvList.js<br/>Pagination]
+        DisplayJS["display.js\nTab management"]
+        TabsJS["ra.tabs.js\nTab functionality"]
+        CvListJS["cvList.js\nPagination"]
     end
 
     DisplayBase --> StdDisplay
@@ -196,22 +196,22 @@ sequenceDiagram
     participant LeafletMap as RLeafletMap
     participant LeafletScript as RLeafletScript
     participant Load as RLoad
-    participant JS as display.js
+    participant JS as "display.js"
     participant Browser as Browser
 
-    Feed->>StdDisplay: display(StdDisplay)
-    Feed->>StdDisplay: DisplayWalks(Walks)
-    StdDisplay->>Walks: sort(date, time, distance)
-    StdDisplay->>Walks: allWalks()
-    StdDisplay->>LeafletMap: new()
-    StdDisplay->>LeafletMap: setCommand("ra.display.walksTabs")
-    StdDisplay->>LeafletMap: setDataObject(walks + config)
-    StdDisplay->>LeafletMap: display()
-    LeafletMap->>LeafletScript: add(options)
-    LeafletScript->>Load: addScript/Style()
+    Feed->>StdDisplay: "display(StdDisplay)"
+    Feed->>StdDisplay: "DisplayWalks(Walks)"
+    StdDisplay->>Walks: "sort(date, time, distance)"
+    StdDisplay->>Walks: "allWalks()"
+    StdDisplay->>LeafletMap: "new()"
+    StdDisplay->>LeafletMap: "setCommand(\"ra.display.walksTabs\")"
+    StdDisplay->>LeafletMap: "setDataObject(walks + config)"
+    StdDisplay->>LeafletMap: "display()"
+    LeafletMap->>LeafletScript: "add(options)"
+    LeafletScript->>Load: "addScript/Style()"
     Load->>Browser: Inject assets
-    JS->>Browser: Initialize tabs, filters, pagination
-    JS->>Browser: Render List/Table/Calendar/Map views
+    JS->>Browser: "Initialize tabs, filters, pagination"
+    JS->>Browser: "Render List/Table/Calendar/Map views"
 ```
 
 ### Simple List Flow
@@ -223,12 +223,12 @@ sequenceDiagram
     participant Walks as RJsonwalksWalks
     participant Walk as RJsonwalksWalk
 
-    Feed->>SimpleList: display(SimpleList)
-    Feed->>SimpleList: DisplayWalks(Walks)
-    SimpleList->>Walks: sort(date, time, distance)
-    SimpleList->>Walks: allWalks()
+    Feed->>SimpleList: "display(SimpleList)"
+    Feed->>SimpleList: "DisplayWalks(Walks)"
+    SimpleList->>Walks: "sort(date, time, distance)"
+    SimpleList->>Walks: "allWalks()"
     loop for each walk
-        SimpleList->>Walk: getWalkValue() for each format token
+        SimpleList->>Walk: "getWalkValue() for each format token"
         Walk-->>SimpleList: formatted value
         SimpleList->>SimpleList: render HTML row
     end

--- a/jsonwalks/std/HLD.md
+++ b/jsonwalks/std/HLD.md
@@ -18,14 +18,14 @@ The `jsonwalks/std` module provides standard display implementations for renderi
 ```mermaid
 flowchart TB
     subgraph Base["Base Class"]
-        DisplayBase["RJsonwalksDisplaybase\nAbstract base"]
+        DisplayBase["RJsonwalksDisplaybase<br/>Abstract base"]
     end
 
     subgraph StdDisplays["Standard Display Classes"]
-        StdDisplay["RJsonwalksStdDisplay\nTabbed interface"]
-        SimpleList["RJsonwalksStdSimplelist\nSimple list"]
-        WalkTable["RJsonwalksStdWalktable\nTable format"]
-        Cancelled["RJsonwalksStdCancelledwalks\nCancelled walks"]
+        StdDisplay["RJsonwalksStdDisplay<br/>Tabbed interface"]
+        SimpleList["RJsonwalksStdSimplelist<br/>Simple list"]
+        WalkTable["RJsonwalksStdWalktable<br/>Table format"]
+        Cancelled["RJsonwalksStdCancelledwalks<br/>Cancelled walks"]
     end
 
     subgraph Integration["Integration Layer"]
@@ -36,9 +36,9 @@ flowchart TB
     end
 
     subgraph Client["Client-Side"]
-        DisplayJS["display.js\nTab management"]
-        TabsJS["ra.tabs.js\nTab functionality"]
-        CvListJS["cvList.js\nPagination"]
+        DisplayJS["display.js<br/>Tab management"]
+        TabsJS["ra.tabs.js<br/>Tab functionality"]
+        CvListJS["cvList.js<br/>Pagination"]
     end
 
     DisplayBase --> StdDisplay
@@ -204,7 +204,7 @@ sequenceDiagram
     StdDisplay->>Walks: "sort(date, time, distance)"
     StdDisplay->>Walks: "allWalks()"
     StdDisplay->>LeafletMap: "new()"
-    StdDisplay->>LeafletMap: "setCommand(\"ra.display.walksTabs\")"
+    StdDisplay->>LeafletMap: "setCommand(ra.display.walksTabs)"
     StdDisplay->>LeafletMap: "setDataObject(walks + config)"
     StdDisplay->>LeafletMap: "display()"
     LeafletMap->>LeafletScript: "add(options)"
@@ -428,4 +428,3 @@ class RJsonwalksBU51Tabs extends RJsonwalksStdDisplay {
 - `media/vendors/fullcalendar-6.1.9/index.global.js` - Calendar view
 - `media/css/ra.tabs.css` - Tab styles
 - `media/vendors/cvList/cvList.css` - Pagination styles
-

--- a/jsonwalks/walk/HLD.md
+++ b/jsonwalks/walk/HLD.md
@@ -17,18 +17,18 @@ The `jsonwalks/walk` module provides domain value objects representing individua
 ```mermaid
 flowchart TB
     subgraph Walk["Walk Aggregate"]
-        WalkRoot[RJsonwalksWalk<br/>Aggregate root]
+        WalkRoot["RJsonwalksWalk\nAggregate root"]
     end
 
     subgraph Components["Value Objects"]
-        Admin[RJsonwalksWalkAdmin<br/>Admin data]
-        Basics[RJsonwalksWalkBasics<br/>Basic info]
-        Items[RJsonwalksWalkItems<br/>Items collection]
-        TimeLoc[RJsonwalksWalkTimelocation<br/>Time/location]
-        Flags[RJsonwalksWalkFlags<br/>Status flags]
-        Bookings[RJsonwalksWalkBookings<br/>Booking info]
-        MediaItem[RJsonwalksWalkMediaitem<br/>Media files]
-        WalkVO[RJsonwalksWalkWalk<br/>Walk details]
+        Admin["RJsonwalksWalkAdmin\nAdmin data"]
+        Basics["RJsonwalksWalkBasics\nBasic info"]
+        Items["RJsonwalksWalkItems\nItems collection"]
+        TimeLoc["RJsonwalksWalkTimelocation\nTime/location"]
+        Flags["RJsonwalksWalkFlags\nStatus flags"]
+        Bookings["RJsonwalksWalkBookings\nBooking info"]
+        MediaItem["RJsonwalksWalkMediaitem\nMedia files"]
+        WalkVO["RJsonwalksWalkWalk\nWalk details"]
     end
 
     WalkRoot --> Admin
@@ -93,17 +93,17 @@ flowchart TB
 sequenceDiagram
     participant Source as RJsonwalksSource*
     participant Walk as RJsonwalksWalk
-    participant Components as Admin/Basics/Items/Flags/Bookings/Mediaitem
+    participant Components as "Admin/Basics/Items/Flags/Bookings/Mediaitem"
     participant Collection as RJsonwalksWalks
     participant Presenter as RJsonwalksDisplaybase subclass
 
-    Source->>Walk: new RJsonwalksWalk()
+    Source->>Walk: "new RJsonwalksWalk()"
     Source->>Components: build component objects
-    Components-->>Walk: add*(component)
-    Walk-->>Collection: addWalk(Walk)
-    Presenter->>Collection: allWalks()
-    Presenter->>Walk: getWalkValue(), isCancelled(), distanceFromLatLong()
-    Walk-->>Presenter: formatted values/status
+    Components-->>Walk: "add*(component)"
+    Walk-->>Collection: "addWalk(Walk)"
+    Presenter->>Collection: "allWalks()"
+    Presenter->>Walk: "getWalkValue(), isCancelled(), distanceFromLatLong()"
+    Walk-->>Presenter: "formatted values/status"
 ```
 
 ## Integration Points

--- a/jsonwalks/walk/HLD.md
+++ b/jsonwalks/walk/HLD.md
@@ -17,18 +17,18 @@ The `jsonwalks/walk` module provides domain value objects representing individua
 ```mermaid
 flowchart TB
     subgraph Walk["Walk Aggregate"]
-        WalkRoot["RJsonwalksWalk\nAggregate root"]
+        WalkRoot["RJsonwalksWalk<br/>Aggregate root"]
     end
 
     subgraph Components["Value Objects"]
-        Admin["RJsonwalksWalkAdmin\nAdmin data"]
-        Basics["RJsonwalksWalkBasics\nBasic info"]
-        Items["RJsonwalksWalkItems\nItems collection"]
-        TimeLoc["RJsonwalksWalkTimelocation\nTime/location"]
-        Flags["RJsonwalksWalkFlags\nStatus flags"]
-        Bookings["RJsonwalksWalkBookings\nBooking info"]
-        MediaItem["RJsonwalksWalkMediaitem\nMedia files"]
-        WalkVO["RJsonwalksWalkWalk\nWalk details"]
+        Admin["RJsonwalksWalkAdmin<br/>Admin data"]
+        Basics["RJsonwalksWalkBasics<br/>Basic info"]
+        Items["RJsonwalksWalkItems<br/>Items collection"]
+        TimeLoc["RJsonwalksWalkTimelocation<br/>Time/location"]
+        Flags["RJsonwalksWalkFlags<br/>Status flags"]
+        Bookings["RJsonwalksWalkBookings<br/>Booking info"]
+        MediaItem["RJsonwalksWalkMediaitem<br/>Media files"]
+        WalkVO["RJsonwalksWalkWalk<br/>Walk details"]
     end
 
     WalkRoot --> Admin

--- a/jsonwalks/wm/HLD.md
+++ b/jsonwalks/wm/HLD.md
@@ -20,12 +20,12 @@ The `jsonwalks/wm` module provides the Walks Manager integration layer for Rambl
 
 ```mermaid
 flowchart TB
-    Caller[Joomla module/page]
+    Caller["Joomla module/page"]
     Source[RJsonwalksSourcewalksmanager]
     Feed[RJsonwalksWmFeed]
-    Options[RJsonwalksWmFeedoptions<br/>URL + cache key]
-    Cache[RJsonwalksWmCachefolder<br/>read/write/mtime]
-    Fileio[RJsonwalksWmFileio<br/>HTTP/local IO, retries]
+    Options["RJsonwalksWmFeedoptions\nURL + cache key"]
+    Cache["RJsonwalksWmCachefolder\nread/write/mtime"]
+    Fileio["RJsonwalksWmFileio\nHTTP/local IO, retries"]
 
     Caller --> Source
     Source --> Feed

--- a/jsonwalks/wm/HLD.md
+++ b/jsonwalks/wm/HLD.md
@@ -23,9 +23,9 @@ flowchart TB
     Caller["Joomla module/page"]
     Source[RJsonwalksSourcewalksmanager]
     Feed[RJsonwalksWmFeed]
-    Options["RJsonwalksWmFeedoptions\nURL + cache key"]
-    Cache["RJsonwalksWmCachefolder\nread/write/mtime"]
-    Fileio["RJsonwalksWmFileio\nHTTP/local IO, retries"]
+    Options["RJsonwalksWmFeedoptions<br/>URL + cache key"]
+    Cache["RJsonwalksWmCachefolder<br/>read/write/mtime"]
+    Fileio["RJsonwalksWmFileio<br/>HTTP/local IO, retries"]
 
     Caller --> Source
     Source --> Feed

--- a/leaflet/HLD.md
+++ b/leaflet/HLD.md
@@ -19,29 +19,29 @@ The `leaflet` module provides comprehensive Leaflet.js map integration for the R
 ```mermaid
 flowchart TB
     subgraph Core["Core Map Classes"]
-        Map[RLeafletMap<br/>Map container]
-        Script[RLeafletScript<br/>Script injection]
-        Options[RLeafletMapoptions<br/>Configuration]
+        Map["RLeafletMap\nMap container"]
+        Script["RLeafletScript\nScript injection"]
+        Options["RLeafletMapoptions\nConfiguration"]
     end
 
     subgraph DataSources["Data Source Adapters"]
-        CsvList[RLeafletCsvList<br/>CSV data]
-        GpxMap[RLeafletGpxMap<br/>GPX routes]
-        JsonList[RLeafletJsonList<br/>JSON data]
-        SqlList[RLeafletSqlList<br/>SQL queries]
-        TableCols[RLeafletTableColumns<br/>Column definitions]
+        CsvList["RLeafletCsvList\nCSV data"]
+        GpxMap["RLeafletGpxMap\nGPX routes"]
+        JsonList["RLeafletJsonList\nJSON data"]
+        SqlList["RLeafletSqlList\nSQL queries"]
+        TableCols["RLeafletTableColumns\nColumn definitions"]
     end
 
     subgraph Client["Client-Side"]
-        Bootstrap[ra.bootstrapper<br/>Initialization]
-        LeafletMapJS[ra.leafletmap.js<br/>Map management]
-        PlacesJS[L.Control.Places.js<br/>Place management]
-        Controls[Map Controls<br/>Mouse, Search, Tools, etc.]
+        Bootstrap["ra.bootstrapper\nInitialization"]
+        LeafletMapJS["ra.leafletmap.js\nMap management"]
+        PlacesJS["L.Control.Places.js\nPlace management"]
+        Controls["Map Controls\nMouse, Search, Tools, etc."]
     end
 
     subgraph Integration["Integration"]
-        Load[RLoad<br/>Asset loading]
-        Doc[Joomla Document<br/>Script injection]
+        Load["RLoad\nAsset loading"]
+        Doc["Joomla Document\nScript injection"]
     end
 
     Map --> Script
@@ -228,21 +228,21 @@ sequenceDiagram
     participant Load as RLoad
     participant Doc as Joomla Document
     participant Browser as Browser
-    participant Bootstrap as ra.bootstrapper
+    participant Bootstrap as "ra.bootstrapper"
 
-    Display->>Map: new()
-    Map->>Options: new()
-    Map->>Script: new(options)
-    Display->>Map: setCommand("ra.display.walksTabs")
-    Display->>Map: setDataObject(walks + config)
-    Display->>Map: display()
-    Map->>Script: add(options)
-    Script->>Options: setLicenses()
-    Script->>Load: addScript/Style() for each asset
-    Load->>Doc: Enqueue Leaflet core, plugins, styles
-    Script->>Doc: addScriptDeclaration(bootstrap code)
+    Display->>Map: "new()"
+    Map->>Options: "new()"
+    Map->>Script: "new(options)"
+    Display->>Map: "setCommand(\"ra.display.walksTabs\")"
+    Display->>Map: "setDataObject(walks + config)"
+    Display->>Map: "display()"
+    Map->>Script: "add(options)"
+    Script->>Options: "setLicenses()"
+    Script->>Load: "addScript/Style() for each asset"
+    Load->>Doc: "Enqueue Leaflet core, plugins, styles"
+    Script->>Doc: "addScriptDeclaration(bootstrap code)"
     Doc->>Browser: Render page with scripts
-    Browser->>Bootstrap: ra.bootstrapper(jv, command, mapOptions, data)
+    Browser->>Bootstrap: "ra.bootstrapper(jv, command, mapOptions, data)"
     Bootstrap->>Browser: Initialize map with data
 ```
 
@@ -250,19 +250,19 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Caller as Module/Page
+    participant Caller as "Module/Page"
     participant CsvList as RLeafletCsvList
     participant Map as RLeafletMap
     participant Script as RLeafletScript
     participant Browser as Browser
 
-    Caller->>CsvList: new(filename)
-    CsvList->>CsvList: readCSV()
-    Caller->>CsvList: display()
-    CsvList->>Map: setCommand("ra.display.csvList")
-    CsvList->>Map: setDataObject(csv data)
-    CsvList->>Map: display()
-    Map->>Script: add(options)
+    Caller->>CsvList: "new(filename)"
+    CsvList->>CsvList: "readCSV()"
+    Caller->>CsvList: "display()"
+    CsvList->>Map: "setCommand(\"ra.display.csvList\")"
+    CsvList->>Map: "setDataObject(csv data)"
+    CsvList->>Map: "display()"
+    Map->>Script: "add(options)"
     Script->>Browser: Inject scripts + data
     Browser->>Browser: Render map with CSV markers
 ```
@@ -307,11 +307,11 @@ flowchart LR
     Map[RLeafletMap]
     Script[RLeafletScript]
     Loader[RLoad]
-    BaseJS[media/js<br/>ra.js<br/>ra.map.js<br/>ra.tabs.js<br/>ra.paginatedDataList.js<br/>ra.walk.js]
+    BaseJS["media/js\nra.js\nra.map.js\nra.tabs.js\nra.paginatedDataList.js\nra.walk.js"]
     LeafletJS[Leaflet core + CSS]
-    ModuleJS[media/leaflet/ra.leafletmap.js<br/>ra.map.settings.js<br/>L.Control.*]
-    DataJS[media/leaflet/table/ramblerstable.js<br/>media/leaflet/gpx/maplist.js]
-    Vendors[media/vendors/**/* + CDN plugins]
+    ModuleJS["media/leaflet/ra.leafletmap.js\nra.map.settings.js\nL.Control.*"]
+    DataJS["media/leaflet/table/ramblerstable.js\nmedia/leaflet/gpx/maplist.js"]
+    Vendors["media/vendors/**/* + CDN plugins"]
 
     Map --> Script
     Script --> Loader

--- a/leaflet/HLD.md
+++ b/leaflet/HLD.md
@@ -19,29 +19,29 @@ The `leaflet` module provides comprehensive Leaflet.js map integration for the R
 ```mermaid
 flowchart TB
     subgraph Core["Core Map Classes"]
-        Map["RLeafletMap\nMap container"]
-        Script["RLeafletScript\nScript injection"]
-        Options["RLeafletMapoptions\nConfiguration"]
+        Map["RLeafletMap<br/>Map container"]
+        Script["RLeafletScript<br/>Script injection"]
+        Options["RLeafletMapoptions<br/>Configuration"]
     end
 
     subgraph DataSources["Data Source Adapters"]
-        CsvList["RLeafletCsvList\nCSV data"]
-        GpxMap["RLeafletGpxMap\nGPX routes"]
-        JsonList["RLeafletJsonList\nJSON data"]
-        SqlList["RLeafletSqlList\nSQL queries"]
-        TableCols["RLeafletTableColumns\nColumn definitions"]
+        CsvList["RLeafletCsvList<br/>CSV data"]
+        GpxMap["RLeafletGpxMap<br/>GPX routes"]
+        JsonList["RLeafletJsonList<br/>JSON data"]
+        SqlList["RLeafletSqlList<br/>SQL queries"]
+        TableCols["RLeafletTableColumns<br/>Column definitions"]
     end
 
     subgraph Client["Client-Side"]
-        Bootstrap["ra.bootstrapper\nInitialization"]
-        LeafletMapJS["ra.leafletmap.js\nMap management"]
-        PlacesJS["L.Control.Places.js\nPlace management"]
-        Controls["Map Controls\nMouse, Search, Tools, etc."]
+        Bootstrap["ra.bootstrapper<br/>Initialization"]
+        LeafletMapJS["ra.leafletmap.js<br/>Map management"]
+        PlacesJS["L.Control.Places.js<br/>Place management"]
+        Controls["Map Controls<br/>Mouse, Search, Tools, etc."]
     end
 
     subgraph Integration["Integration"]
-        Load["RLoad\nAsset loading"]
-        Doc["Joomla Document\nScript injection"]
+        Load["RLoad<br/>Asset loading"]
+        Doc["Joomla Document<br/>Script injection"]
     end
 
     Map --> Script
@@ -233,7 +233,7 @@ sequenceDiagram
     Display->>Map: "new()"
     Map->>Options: "new()"
     Map->>Script: "new(options)"
-    Display->>Map: "setCommand(\"ra.display.walksTabs\")"
+    Display->>Map: "setCommand(ra.display.walksTabs)"
     Display->>Map: "setDataObject(walks + config)"
     Display->>Map: "display()"
     Map->>Script: "add(options)"
@@ -259,7 +259,7 @@ sequenceDiagram
     Caller->>CsvList: "new(filename)"
     CsvList->>CsvList: "readCSV()"
     Caller->>CsvList: "display()"
-    CsvList->>Map: "setCommand(\"ra.display.csvList\")"
+    CsvList->>Map: "setCommand(ra.display.csvList)"
     CsvList->>Map: "setDataObject(csv data)"
     CsvList->>Map: "display()"
     Map->>Script: "add(options)"
@@ -307,10 +307,10 @@ flowchart LR
     Map[RLeafletMap]
     Script[RLeafletScript]
     Loader[RLoad]
-    BaseJS["media/js\nra.js\nra.map.js\nra.tabs.js\nra.paginatedDataList.js\nra.walk.js"]
+    BaseJS["media/js<br/>ra.js<br/>ra.map.js<br/>ra.tabs.js<br/>ra.paginatedDataList.js<br/>ra.walk.js"]
     LeafletJS[Leaflet core + CSS]
-    ModuleJS["media/leaflet/ra.leafletmap.js\nra.map.settings.js\nL.Control.*"]
-    DataJS["media/leaflet/table/ramblerstable.js\nmedia/leaflet/gpx/maplist.js"]
+    ModuleJS["media/leaflet/ra.leafletmap.js<br/>ra.map.settings.js<br/>L.Control.*"]
+    DataJS["media/leaflet/table/ramblerstable.js<br/>media/leaflet/gpx/maplist.js"]
     Vendors["media/vendors/**/* + CDN plugins"]
 
     Map --> Script

--- a/leaflet/gpx/HLD.md
+++ b/leaflet/gpx/HLD.md
@@ -59,9 +59,9 @@ public function display();
 flowchart TB
     Map[RLeafletGpxMap]
     Maplist[RLeafletGpxMaplist]
-    Stats["RGpxStatistics\nRGpxJsonlog"]
+    Stats["RGpxStatistics<br/>RGpxJsonlog"]
     Parser["RGpxFile / RGpxStatistic"]
-    Media["media/leaflet/gpx/maplist.js\nLeaflet.Elevation + leaflet-gpx"]
+    Media["media/leaflet/gpx/maplist.js<br/>Leaflet.Elevation + leaflet-gpx"]
 
     Maplist --> Stats
     Stats --> Parser
@@ -122,7 +122,7 @@ flowchart LR
     Loader[RLeafletScript + RLoad]
     BaseJS["/media/js foundation"]
     GpxJS["/media/leaflet/gpx/maplist.js"]
-    Vendors["/media/vendors\nleaflet-gpx + Leaflet.Elevation + cvList"]
+    Vendors["/media/vendors<br/>leaflet-gpx + Leaflet.Elevation + cvList"]
     Bootstrap["ra.bootstrapper → ra.display.gpxSingle/gpxFolder"]
 
     PHP --> Loader

--- a/leaflet/gpx/HLD.md
+++ b/leaflet/gpx/HLD.md
@@ -59,9 +59,9 @@ public function display();
 flowchart TB
     Map[RLeafletGpxMap]
     Maplist[RLeafletGpxMaplist]
-    Stats[RGpxStatistics<br/>RGpxJsonlog]
-    Parser[RGpxFile / RGpxStatistic]
-    Media[/media/leaflet/gpx/maplist.js<br/>Leaflet.Elevation + leaflet-gpx/]
+    Stats["RGpxStatistics\nRGpxJsonlog"]
+    Parser["RGpxFile / RGpxStatistic"]
+    Media["media/leaflet/gpx/maplist.js\nLeaflet.Elevation + leaflet-gpx"]
 
     Maplist --> Stats
     Stats --> Parser
@@ -74,17 +74,17 @@ flowchart TB
 ```mermaid
 sequenceDiagram
     participant Caller
-    participant Map as RLeafletGpxMap(list)
+    participant Map as "RLeafletGpxMap(list)"
     participant Stats as RGpxStatistics
-    participant Media as ra.display.gpxFolder/ra.display.gpxSingle
+    participant Media as "ra.display.gpxFolder/ra.display.gpxSingle"
 
-    Caller->>Map: display()/displayPath()
+    Caller->>Map: "display()/displayPath()"
     alt folder mode
-        Map->>Stats: build 0000gpx_statistics_file.json
+        Map->>Stats: "build 0000gpx_statistics_file.json"
         Stats-->>Map: cached JSON
-        Map->>Media: setCommand('ra.display.gpxFolder') + data
+        Map->>Media: "setCommand('ra.display.gpxFolder') + data"
     else single file
-        Map->>Media: setCommand('ra.display.gpxSingle') + file metadata
+        Map->>Media: "setCommand('ra.display.gpxSingle') + file metadata"
     end
     Media-->>Caller: HTML + bootstrap with asset list
 ```
@@ -118,12 +118,12 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP[RLeafletGpxMap / Maplist]
+    PHP["RLeafletGpxMap / Maplist"]
     Loader[RLeafletScript + RLoad]
-    BaseJS[/media/js foundation]
-    GpxJS[/media/leaflet/gpx/maplist.js]
-    Vendors[/media/vendors<br/>leaflet-gpx + Leaflet.Elevation + cvList]
-    Bootstrap[ra.bootstrapper → ra.display.gpxSingle/gpxFolder]
+    BaseJS["/media/js foundation"]
+    GpxJS["/media/leaflet/gpx/maplist.js"]
+    Vendors["/media/vendors\nleaflet-gpx + Leaflet.Elevation + cvList"]
+    Bootstrap["ra.bootstrapper → ra.display.gpxSingle/gpxFolder"]
 
     PHP --> Loader
     Loader --> BaseJS

--- a/leaflet/table/HLD.md
+++ b/leaflet/table/HLD.md
@@ -16,7 +16,7 @@ The `leaflet/table` module provides table column definition utilities for Leafle
 flowchart TB
     Columns[RLeafletTableColumns]
     Column[RLeafletTableColumn]
-    Sources[CSV/JSON/SQL lists]
+    Sources["CSV/JSON/SQL lists"]
 
     Columns --> Column
     Sources --> Columns

--- a/license/HLD.md
+++ b/license/HLD.md
@@ -12,9 +12,9 @@ The `license` module provides license key management for map providers and exter
 
 ```mermaid
 flowchart TB
-    RLicense[RLicense<br/>License lookup]
-    Joomla[Joomla Config<br/>Component params]
-    Consumers[RLeafletMapoptions<br/>Leaflet presenters]
+    RLicense["RLicense\nLicense lookup"]
+    Joomla["Joomla Config\nComponent params"]
+    Consumers["RLeafletMapoptions\nLeaflet presenters"]
 
     RLicense --> Joomla
     RLicense --> Consumers
@@ -41,9 +41,9 @@ sequenceDiagram
     participant License as RLicense
     participant Joomla as Joomla Config
 
-    Caller->>License: get...LicenseKey()
+    Caller->>License: "get...LicenseKey()"
     License->>Joomla: read component params
-    Joomla-->>License: key or ""
+    Joomla-->>License: "key or \"\""
     License-->>Caller: key string
 ```
 

--- a/license/HLD.md
+++ b/license/HLD.md
@@ -12,9 +12,9 @@ The `license` module provides license key management for map providers and exter
 
 ```mermaid
 flowchart TB
-    RLicense["RLicense\nLicense lookup"]
-    Joomla["Joomla Config\nComponent params"]
-    Consumers["RLeafletMapoptions\nLeaflet presenters"]
+    RLicense["RLicense<br/>License lookup"]
+    Joomla["Joomla Config<br/>Component params"]
+    Consumers["RLeafletMapoptions<br/>Leaflet presenters"]
 
     RLicense --> Joomla
     RLicense --> Consumers
@@ -43,7 +43,7 @@ sequenceDiagram
 
     Caller->>License: "get...LicenseKey()"
     License->>Joomla: read component params
-    Joomla-->>License: "key or \"\""
+    Joomla-->>License: "key or empty"
     License-->>Caller: key string
 ```
 
@@ -82,4 +82,3 @@ sequenceDiagram
 
 - `license/license.php` - License key management
 - [leaflet HLD](../leaflet/HLD.md) - License key usage
-

--- a/load/HLD.md
+++ b/load/HLD.md
@@ -17,22 +17,22 @@ The `load` module provides asset loading utilities with cache-busting support. I
 ```mermaid
 flowchart TB
     subgraph Load["Load Module"]
-        RLoad[RLoad<br/>Static utility class]
+        RLoad["RLoad\nStatic utility class"]
     end
 
     subgraph Functions["Functions"]
-        AddScript[addScript<br/>Load JS]
-        AddStyleSheet[addStyleSheet<br/>Load CSS]
+        AddScript["addScript\nLoad JS"]
+        AddStyleSheet["addStyleSheet\nLoad CSS"]
     end
 
     subgraph Integration["Integration"]
-        JoomlaDoc[Joomla Document<br/>addScript/addStyleSheet]
-        DisplayModules[Display Modules<br/>Asset loading]
+        JoomlaDoc["Joomla Document\naddScript/addStyleSheet"]
+        DisplayModules["Display Modules\nAsset loading"]
     end
 
     subgraph CacheBusting["Cache Busting"]
-        FileMtime[filemtime()<br/>Get modification time]
-        QueryString[?rev=timestamp<br/>Version query]
+        FileMtime["filemtime()\nGet modification time"]
+        QueryString["?rev=timestamp\nVersion query"]
     end
 
     RLoad --> AddScript
@@ -89,17 +89,17 @@ sequenceDiagram
     participant JoomlaDoc as Joomla Document
     participant Browser as Browser
 
-    Display->>RLoad: addScript('path/to/file.js')
+    Display->>RLoad: "addScript('path/to/file.js')"
     RLoad->>RLoad: Check if HTTP URL
     alt Local file
-        RLoad->>FileSystem: filemtime('path/to/file.js')
+        RLoad->>FileSystem: "filemtime('path/to/file.js')"
         FileSystem-->>RLoad: timestamp
         RLoad->>RLoad: Append ?rev=timestamp
     else HTTP URL
         RLoad->>RLoad: Use ?rev=0
     end
-    RLoad->>JoomlaDoc: addScript('path/to/file.js?rev=timestamp')
-    JoomlaDoc->>Browser: Inject <script> tag
+    RLoad->>JoomlaDoc: "addScript('path/to/file.js?rev=timestamp')"
+    JoomlaDoc->>Browser: "Inject <script> tag"
 ```
 
 ## Integration Points

--- a/load/HLD.md
+++ b/load/HLD.md
@@ -17,22 +17,22 @@ The `load` module provides asset loading utilities with cache-busting support. I
 ```mermaid
 flowchart TB
     subgraph Load["Load Module"]
-        RLoad["RLoad\nStatic utility class"]
+        RLoad["RLoad<br/>Static utility class"]
     end
 
     subgraph Functions["Functions"]
-        AddScript["addScript\nLoad JS"]
-        AddStyleSheet["addStyleSheet\nLoad CSS"]
+        AddScript["addScript<br/>Load JS"]
+        AddStyleSheet["addStyleSheet<br/>Load CSS"]
     end
 
     subgraph Integration["Integration"]
-        JoomlaDoc["Joomla Document\naddScript/addStyleSheet"]
-        DisplayModules["Display Modules\nAsset loading"]
+        JoomlaDoc["Joomla Document<br/>addScript/addStyleSheet"]
+        DisplayModules["Display Modules<br/>Asset loading"]
     end
 
     subgraph CacheBusting["Cache Busting"]
-        FileMtime["filemtime()\nGet modification time"]
-        QueryString["?rev=timestamp\nVersion query"]
+        FileMtime["filemtime()<br/>Get modification time"]
+        QueryString["?rev=timestamp<br/>Version query"]
     end
 
     RLoad --> AddScript

--- a/media/accounts/HLD.md
+++ b/media/accounts/HLD.md
@@ -17,15 +17,15 @@ The `media/accounts` module provides client-side JavaScript for displaying hoste
 ```mermaid
 flowchart TB
     subgraph Core["Core Integration"]
-        Bootstrap[ra.bootstrapper<br/>Initialization]
-        LeafletMap[ra.leafletmap<br/>Map wrapper]
-        Cluster[ra.map.cluster<br/>Marker clustering]
+        Bootstrap["ra.bootstrapper\nInitialization"]
+        LeafletMap["ra.leafletmap\nMap wrapper"]
+        Cluster["ra.map.cluster\nMarker clustering"]
     end
 
     subgraph Display["Display Function"]
-        AccountsMap[ra.display.accountsMap<br/>Accounts display]
-        Markers[Account Markers<br/>Marker rendering]
-        Popups[Popups<br/>Account information]
+        AccountsMap["ra.display.accountsMap\nAccounts display"]
+        Markers["Account Markers\nMarker rendering"]
+        Popups["Popups\nAccount information"]
     end
 
     Bootstrap --> AccountsMap
@@ -82,27 +82,27 @@ sequenceDiagram
     autonumber
     participant PHP as RAccounts
     participant Doc as Joomla Document
-    participant Bootstrap as ra.bootstrapper
-    participant AccountsMap as ra.display.accountsMap
-    participant LeafletMap as ra.leafletmap
-    participant Cluster as ra.map.cluster
+    participant Bootstrap as "ra.bootstrapper"
+    participant AccountsMap as "ra.display.accountsMap"
+    participant LeafletMap as "ra.leafletmap"
+    participant Cluster as "ra.map.cluster"
     participant User as User Browser
 
-    PHP->>Doc: setCommand("ra.display.accountsMap")
-    PHP->>Doc: setDataObject(hostedsites)
-    PHP->>Doc: addScriptDeclaration(bootstrap)
+    PHP->>Doc: "setCommand(\"ra.display.accountsMap\")"
+    PHP->>Doc: "setDataObject(hostedsites)"
+    PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
-    User->>Bootstrap: ra.bootstrapper(jv, class, opts, data)
-    Bootstrap->>AccountsMap: new AccountsMap(options, data)
-    AccountsMap->>AccountsMap: load()
-    AccountsMap->>LeafletMap: new ra.leafletmap(div, options)
-    AccountsMap->>Cluster: new ra.map.cluster(map)
-    AccountsMap->>AccountsMap: addMarkers(hostedsites)
+    User->>Bootstrap: "ra.bootstrapper(jv, class, opts, data)"
+    Bootstrap->>AccountsMap: "new AccountsMap(options, data)"
+    AccountsMap->>AccountsMap: "load()"
+    AccountsMap->>LeafletMap: "new ra.leafletmap(div, options)"
+    AccountsMap->>Cluster: "new ra.map.cluster(map)"
+    AccountsMap->>AccountsMap: "addMarkers(hostedsites)"
     loop for each site (if not DELETED)
-        AccountsMap->>AccountsMap: addMarker(site)
+        AccountsMap->>AccountsMap: "addMarker(site)"
     end
-    AccountsMap->>Cluster: addClusterMarkers()
-    AccountsMap->>Cluster: zoomAll()
+    AccountsMap->>Cluster: "addClusterMarkers()"
+    AccountsMap->>Cluster: "zoomAll()"
     AccountsMap->>User: Display map
 ```
 
@@ -132,12 +132,12 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP[RAccounts::addMapMarkers]
-    Loader[RLoad::addScript]
-    Map[RLeafletMap::display]
-    BaseJS[/media/js<br/>ra.js, ra.leafletmap.js, ra.tabs.js]
-    AccountsJS[/media/accounts/accounts.js]
-    Bootstrap[ra.bootstrapper → ra.display.accountsMap]
+    PHP["RAccounts::addMapMarkers"]
+    Loader["RLoad::addScript"]
+    Map["RLeafletMap::display"]
+    BaseJS["/media/js\nra.js, ra.leafletmap.js, ra.tabs.js"]
+    AccountsJS["/media/accounts/accounts.js"]
+    Bootstrap["ra.bootstrapper → ra.display.accountsMap"]
 
     PHP --> Loader
     Loader --> BaseJS

--- a/media/accounts/HLD.md
+++ b/media/accounts/HLD.md
@@ -17,15 +17,15 @@ The `media/accounts` module provides client-side JavaScript for displaying hoste
 ```mermaid
 flowchart TB
     subgraph Core["Core Integration"]
-        Bootstrap["ra.bootstrapper\nInitialization"]
-        LeafletMap["ra.leafletmap\nMap wrapper"]
-        Cluster["ra.map.cluster\nMarker clustering"]
+        Bootstrap["ra.bootstrapper<br/>Initialization"]
+        LeafletMap["ra.leafletmap<br/>Map wrapper"]
+        Cluster["ra.map.cluster<br/>Marker clustering"]
     end
 
     subgraph Display["Display Function"]
-        AccountsMap["ra.display.accountsMap\nAccounts display"]
-        Markers["Account Markers\nMarker rendering"]
-        Popups["Popups\nAccount information"]
+        AccountsMap["ra.display.accountsMap<br/>Accounts display"]
+        Markers["Account Markers<br/>Marker rendering"]
+        Popups["Popups<br/>Account information"]
     end
 
     Bootstrap --> AccountsMap
@@ -88,7 +88,7 @@ sequenceDiagram
     participant Cluster as "ra.map.cluster"
     participant User as User Browser
 
-    PHP->>Doc: "setCommand(\"ra.display.accountsMap\")"
+    PHP->>Doc: "setCommand(ra.display.accountsMap)"
     PHP->>Doc: "setDataObject(hostedsites)"
     PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
@@ -135,7 +135,7 @@ flowchart LR
     PHP["RAccounts::addMapMarkers"]
     Loader["RLoad::addScript"]
     Map["RLeafletMap::display"]
-    BaseJS["/media/js\nra.js, ra.leafletmap.js, ra.tabs.js"]
+    BaseJS["/media/js<br/>ra.js, ra.leafletmap.js, ra.tabs.js"]
     AccountsJS["/media/accounts/accounts.js"]
     Bootstrap["ra.bootstrapper → ra.display.accountsMap"]
 

--- a/media/gpxsymbols/HLD.md
+++ b/media/gpxsymbols/HLD.md
@@ -17,19 +17,19 @@ The `media/gpxsymbols` module provides a PHP endpoint for checking GPX symbol fi
 ```mermaid
 flowchart TB
     subgraph Endpoint["PHP Endpoint"]
-        Exists[exists.php<br/>File check]
+        Exists["exists.php\nFile check"]
     end
 
     subgraph Input["Input"]
-        GETRequest[GET Request<br/>?file=path]
+        GETRequest["GET Request\n?file=path"]
     end
 
     subgraph Output["Output"]
-        Response[true/false<br/>String response]
+        Response["true/false\nString response"]
     end
 
     subgraph FileSystem["File System"]
-        SymbolFiles[Symbol Image Files<br/>letter/, number/, etc.]
+        SymbolFiles["Symbol Image Files\nletter/, number/, etc."]
     end
 
     GETRequest --> Exists
@@ -70,14 +70,14 @@ GET /media/lib_ramblers/gpxsymbols/exists.php?file=<filepath>
 sequenceDiagram
     autonumber
     participant Client as JavaScript Client
-    participant Exists as exists.php
+    participant Exists as "exists.php"
     participant FileSystem as File System
 
-    Client->>Exists: GET ?file=media/.../symbol.png
-    Exists->>Exists: htmlspecialchars(file)
-    Exists->>FileSystem: file_exists(filepath)
-    FileSystem-->>Exists: true/false
-    Exists-->>Client: "true" or "false"
+    Client->>Exists: "GET ?file=media/.../symbol.png"
+    Exists->>Exists: "htmlspecialchars(file)"
+    Exists->>FileSystem: "file_exists(filepath)"
+    FileSystem-->>Exists: "true/false"
+    Exists-->>Client: "true\" or \"false"
 ```
 
 ## Integration Points
@@ -105,9 +105,9 @@ sequenceDiagram
 ```mermaid
 flowchart LR
     Client[Client widget]
-    Exists[media/gpxsymbols/exists.php]
-    Files[/media/gpxsymbols<br/>symbol sprites]
-    Response["true" / "false"]
+    Exists["media/gpxsymbols/exists.php"]
+    Files["/media/gpxsymbols\nsymbol sprites"]
+    Response["true\" / \"false"]
 
     Client --> Exists
     Exists --> Files

--- a/media/gpxsymbols/HLD.md
+++ b/media/gpxsymbols/HLD.md
@@ -17,19 +17,19 @@ The `media/gpxsymbols` module provides a PHP endpoint for checking GPX symbol fi
 ```mermaid
 flowchart TB
     subgraph Endpoint["PHP Endpoint"]
-        Exists["exists.php\nFile check"]
+        Exists["exists.php<br/>File check"]
     end
 
     subgraph Input["Input"]
-        GETRequest["GET Request\n?file=path"]
+        GETRequest["GET Request<br/>?file=path"]
     end
 
     subgraph Output["Output"]
-        Response["true/false\nString response"]
+        Response["true/false<br/>String response"]
     end
 
     subgraph FileSystem["File System"]
-        SymbolFiles["Symbol Image Files\nletter/, number/, etc."]
+        SymbolFiles["Symbol Image Files<br/>letter/, number/, etc."]
     end
 
     GETRequest --> Exists
@@ -77,7 +77,7 @@ sequenceDiagram
     Exists->>Exists: "htmlspecialchars(file)"
     Exists->>FileSystem: "file_exists(filepath)"
     FileSystem-->>Exists: "true/false"
-    Exists-->>Client: "true\" or \"false"
+    Exists-->>Client: "true or false"
 ```
 
 ## Integration Points
@@ -106,8 +106,8 @@ sequenceDiagram
 flowchart LR
     Client[Client widget]
     Exists["media/gpxsymbols/exists.php"]
-    Files["/media/gpxsymbols\nsymbol sprites"]
-    Response["true\" / \"false"]
+    Files["/media/gpxsymbols<br/>symbol sprites"]
+    Response["true / false"]
 
     Client --> Exists
     Exists --> Files

--- a/media/js/HLD.md
+++ b/media/js/HLD.md
@@ -20,30 +20,30 @@ The `media/js` module provides the core JavaScript library (`ra.*` namespace) th
 ```mermaid
 flowchart TB
     subgraph Core["Core Library (ra.js)"]
-        Bootstrap["ra.bootstrapper\nInitialization"]
-        Utils["ra.* utilities\nString, object, email"]
-        Events["ra.events\nEvent collection"]
-        Loading["ra.loading\nLoading indicators"]
-        Modals["ra.modals\nModal dialogs"]
-        HTML["ra.html\nDOM utilities"]
-        Filter["ra.filter\nFiltering system"]
+        Bootstrap["ra.bootstrapper<br/>Initialization"]
+        Utils["ra.* utilities<br/>String, object, email"]
+        Events["ra.events<br/>Event collection"]
+        Loading["ra.loading<br/>Loading indicators"]
+        Modals["ra.modals<br/>Modal dialogs"]
+        HTML["ra.html<br/>DOM utilities"]
+        Filter["ra.filter<br/>Filtering system"]
     end
 
     subgraph Map["Map Utilities (ra.map.js)"]
-        MapUtils["ra.map.*\nMap helpers"]
-        Icons["ra.map.icon\nIcon factory"]
-        Help["ra.map.helpBase\nHelp URLs"]
+        MapUtils["ra.map.*<br/>Map helpers"]
+        Icons["ra.map.icon<br/>Icon factory"]
+        Help["ra.map.helpBase<br/>Help URLs"]
     end
 
     subgraph Feed["Feed Handler (ra.feedhandler.js)"]
-        FeedHandler["ra.feedhandler\nLocation search"]
-        Search["Modal search form\nLocation lookup"]
+        FeedHandler["ra.feedhandler<br/>Location search"]
+        Search["Modal search form<br/>Location lookup"]
     end
 
     subgraph Display["Display Components"]
-        Tabs["ra.tabs\nTab system"]
-        Pagination["ra.paginatedTable\nPagination"]
-        Walk["ra.walk\nWalk utilities"]
+        Tabs["ra.tabs<br/>Tab system"]
+        Pagination["ra.paginatedTable<br/>Pagination"]
+        Walk["ra.walk<br/>Walk utilities"]
     end
 
     Bootstrap --> Events
@@ -90,7 +90,7 @@ flowchart TB
 ```mermaid
 flowchart LR
     PHP["RLoad::addScript"]
-    Loader["/media/js\nra.js, ra.map.js, ra.feedhandler.js, ra.paginatedDataList.js, ra.tabs.js, ra.walk.js"]
+    Loader["/media/js<br/>ra.js, ra.map.js, ra.feedhandler.js, ra.paginatedDataList.js, ra.tabs.js, ra.walk.js"]
     Module[Module-specific assets]
     Document[Joomla Document]
     Browser["ra.bootstrapper"]
@@ -309,7 +309,7 @@ sequenceDiagram
 
     User->>FilterUI: Change filter value
     FilterUI->>Filter: Update filter state
-    Filter->>Filter: "Dispatch \"reDisplayWalks\" event"
+    Filter->>Filter: "Dispatch reDisplayWalks event"
     Events->>Events: "setDisplayFilter(filter)"
     loop for each event
         Events->>Event: "setDisplayFilter(filter)"

--- a/media/js/HLD.md
+++ b/media/js/HLD.md
@@ -20,30 +20,30 @@ The `media/js` module provides the core JavaScript library (`ra.*` namespace) th
 ```mermaid
 flowchart TB
     subgraph Core["Core Library (ra.js)"]
-        Bootstrap[ra.bootstrapper<br/>Initialization]
-        Utils[ra.* utilities<br/>String, object, email]
-        Events[ra.events<br/>Event collection]
-        Loading[ra.loading<br/>Loading indicators]
-        Modals[ra.modals<br/>Modal dialogs]
-        HTML[ra.html<br/>DOM utilities]
-        Filter[ra.filter<br/>Filtering system]
+        Bootstrap["ra.bootstrapper\nInitialization"]
+        Utils["ra.* utilities\nString, object, email"]
+        Events["ra.events\nEvent collection"]
+        Loading["ra.loading\nLoading indicators"]
+        Modals["ra.modals\nModal dialogs"]
+        HTML["ra.html\nDOM utilities"]
+        Filter["ra.filter\nFiltering system"]
     end
 
     subgraph Map["Map Utilities (ra.map.js)"]
-        MapUtils[ra.map.*<br/>Map helpers]
-        Icons[ra.map.icon<br/>Icon factory]
-        Help[ra.map.helpBase<br/>Help URLs]
+        MapUtils["ra.map.*\nMap helpers"]
+        Icons["ra.map.icon\nIcon factory"]
+        Help["ra.map.helpBase\nHelp URLs"]
     end
 
     subgraph Feed["Feed Handler (ra.feedhandler.js)"]
-        FeedHandler[ra.feedhandler<br/>Location search]
-        Search[Modal search form<br/>Location lookup]
+        FeedHandler["ra.feedhandler\nLocation search"]
+        Search["Modal search form\nLocation lookup"]
     end
 
     subgraph Display["Display Components"]
-        Tabs[ra.tabs<br/>Tab system]
-        Pagination[ra.paginatedTable<br/>Pagination]
-        Walk[ra.walk<br/>Walk utilities]
+        Tabs["ra.tabs\nTab system"]
+        Pagination["ra.paginatedTable\nPagination"]
+        Walk["ra.walk\nWalk utilities"]
     end
 
     Bootstrap --> Events
@@ -89,11 +89,11 @@ flowchart TB
 
 ```mermaid
 flowchart LR
-    PHP[RLoad::addScript]
-    Loader[/media/js<br/>ra.js, ra.map.js, ra.feedhandler.js, ra.paginatedDataList.js, ra.tabs.js, ra.walk.js]
+    PHP["RLoad::addScript"]
+    Loader["/media/js\nra.js, ra.map.js, ra.feedhandler.js, ra.paginatedDataList.js, ra.tabs.js, ra.walk.js"]
     Module[Module-specific assets]
     Document[Joomla Document]
-    Browser[ra.bootstrapper]
+    Browser["ra.bootstrapper"]
 
     PHP --> Loader
     PHP --> Module
@@ -278,22 +278,22 @@ sequenceDiagram
     autonumber
     participant PHP as PHP Display Class
     participant Doc as Joomla Document
-    participant Bootstrap as ra.bootstrapper
+    participant Bootstrap as "ra.bootstrapper"
     participant DisplayClass as Display Class
-    participant Events as ra.events
+    participant Events as "ra.events"
     participant User as User Browser
 
-    PHP->>Doc: addScriptDeclaration(bootstrapper code)
+    PHP->>Doc: "addScriptDeclaration(bootstrapper code)"
     PHP->>Doc: Inject mapOptions and data as JSON
     Doc->>User: Render page with scripts
-    User->>Bootstrap: ra.bootstrapper(jv, class, opts, data)
-    Bootstrap->>Bootstrap: decodeOptions(opts)
-    Bootstrap->>Bootstrap: decodeData(data)
+    User->>Bootstrap: "ra.bootstrapper(jv, class, opts, data)"
+    Bootstrap->>Bootstrap: "decodeOptions(opts)"
+    Bootstrap->>Bootstrap: "decodeData(data)"
     Bootstrap->>Bootstrap: Dynamically instantiate class
-    Bootstrap->>DisplayClass: new DisplayClass(options, data)
-    DisplayClass->>DisplayClass: load()
-    DisplayClass->>Events: new ra.events()
-    DisplayClass->>Events: registerEvent() for each walk
+    Bootstrap->>DisplayClass: "new DisplayClass(options, data)"
+    DisplayClass->>DisplayClass: "load()"
+    DisplayClass->>Events: "new ra.events()"
+    DisplayClass->>Events: "registerEvent() for each walk"
     DisplayClass->>User: Render UI
 ```
 
@@ -303,16 +303,16 @@ sequenceDiagram
 sequenceDiagram
     participant User as User
     participant FilterUI as Filter UI
-    participant Filter as ra.filter
-    participant Events as ra.events
+    participant Filter as "ra.filter"
+    participant Events as "ra.events"
     participant Display as Display Module
 
     User->>FilterUI: Change filter value
     FilterUI->>Filter: Update filter state
-    Filter->>Filter: Dispatch "reDisplayWalks" event
-    Events->>Events: setDisplayFilter(filter)
+    Filter->>Filter: "Dispatch \"reDisplayWalks\" event"
+    Events->>Events: "setDisplayFilter(filter)"
     loop for each event
-        Events->>Event: setDisplayFilter(filter)
+        Events->>Event: "setDisplayFilter(filter)"
         Event->>Event: Evaluate filter criteria
         Event->>Event: Set _displayFiltered flag
     end

--- a/media/jsonwalks/HLD.md
+++ b/media/jsonwalks/HLD.md
@@ -18,27 +18,27 @@ The `media/jsonwalks` module provides client-side JavaScript for rendering walk 
 ```mermaid
 flowchart TB
     subgraph Core["Core Integration"]
-        Bootstrap[ra.bootstrapper<br/>Initialization]
-        Events[ra.events<br/>Event collection]
+        Bootstrap["ra.bootstrapper\nInitialization"]
+        Events["ra.events\nEvent collection"]
     end
 
     subgraph StdDisplay["Standard Display (display.js)"]
-        WalksTabs[ra.display.walksTabs<br/>Tabbed interface]
-        GradesView[Grades View<br/>Grade-based display]
-        ListView[List View<br/>List format]
-        TableView[Table View<br/>Table format]
-        CalendarView[Calendar View<br/>FullCalendar]
-        MapView[Map View<br/>Leaflet map]
+        WalksTabs["ra.display.walksTabs\nTabbed interface"]
+        GradesView["Grades View\nGrade-based display"]
+        ListView["List View\nList format"]
+        TableView["Table View\nTable format"]
+        CalendarView["Calendar View\nFullCalendar"]
+        MapView["Map View\nLeaflet map"]
     end
 
     subgraph MapDisplay["Map Marker Display (mapmarker.js)"]
-        WalksMap[ra.display.walksMap<br/>Map markers]
+        WalksMap["ra.display.walksMap\nMap markers"]
         Cluster[Marker clustering]
     end
 
     subgraph Specialized["Specialized Displays"]
-        MLScript[ml/script.js<br/>Monthly listing]
-        SR02Display[sr02/display.js<br/>SR02 custom format]
+        MLScript["ml/script.js\nMonthly listing"]
+        SR02Display["sr02/display.js\nSR02 custom format"]
     end
 
     Bootstrap --> WalksTabs
@@ -197,24 +197,24 @@ sequenceDiagram
     autonumber
     participant PHP as RJsonwalksStdDisplay
     participant Doc as Joomla Document
-    participant Bootstrap as ra.bootstrapper
-    participant WalksTabs as ra.display.walksTabs
-    participant Events as ra.events
-    participant Tabs as ra.tabs
+    participant Bootstrap as "ra.bootstrapper"
+    participant WalksTabs as "ra.display.walksTabs"
+    participant Events as "ra.events"
+    participant Tabs as "ra.tabs"
     participant User as User Browser
 
-    PHP->>Doc: setCommand("ra.display.walksTabs")
-    PHP->>Doc: setDataObject(walks + config)
-    PHP->>Doc: addScriptDeclaration(bootstrap)
+    PHP->>Doc: "setCommand(\"ra.display.walksTabs\")"
+    PHP->>Doc: "setDataObject(walks + config)"
+    PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
-    User->>Bootstrap: ra.bootstrapper(jv, class, opts, data)
-    Bootstrap->>WalksTabs: new WalksTabs(options, data)
-    WalksTabs->>WalksTabs: load()
-    WalksTabs->>Events: new ra.events()
+    User->>Bootstrap: "ra.bootstrapper(jv, class, opts, data)"
+    Bootstrap->>WalksTabs: "new WalksTabs(options, data)"
+    WalksTabs->>WalksTabs: "load()"
+    WalksTabs->>Events: "new ra.events()"
     loop for each walk
-        WalksTabs->>Events: registerEvent(walk)
+        WalksTabs->>Events: "registerEvent(walk)"
     end
-    WalksTabs->>Tabs: new ra.tabs()
+    WalksTabs->>Tabs: "new ra.tabs()"
     WalksTabs->>User: Render initial tab
 ```
 
@@ -223,24 +223,24 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     participant User as User
-    participant Tabs as ra.tabs
-    participant WalksTabs as ra.display.walksTabs
+    participant Tabs as "ra.tabs"
+    participant WalksTabs as "ra.display.walksTabs"
     participant Display as Display Method
-    participant Events as ra.events
+    participant Events as "ra.events"
 
     User->>Tabs: Click tab button
-    Tabs->>Tabs: Dispatch "displayTabContents" event
-    WalksTabs->>WalksTabs: displayWalks()
+    Tabs->>Tabs: "Dispatch \"displayTabContents\" event"
+    WalksTabs->>WalksTabs: "displayWalks()"
     alt Tab == "List"
-        WalksTabs->>Display: displayWalksList(tag)
+        WalksTabs->>Display: "displayWalksList(tag)"
     else Tab == "Table"
-        WalksTabs->>Display: displayWalksTable(tag)
+        WalksTabs->>Display: "displayWalksTable(tag)"
     else Tab == "Calendar"
-        WalksTabs->>Display: displayWalksCalendar(tag)
+        WalksTabs->>Display: "displayWalksCalendar(tag)"
     else Tab == "Map"
-        WalksTabs->>Display: displayMap(tag)
+        WalksTabs->>Display: "displayMap(tag)"
     end
-    Display->>Events: forEachFiltered(walk => render)
+    Display->>Events: "forEachFiltered(walk => render)"
     Display->>User: Update DOM
 ```
 
@@ -250,15 +250,15 @@ sequenceDiagram
 sequenceDiagram
     participant User as User
     participant FilterUI as Filter UI
-    participant Events as ra.events
-    participant WalksTabs as ra.display.walksTabs
+    participant Events as "ra.events"
+    participant WalksTabs as "ra.display.walksTabs"
 
     User->>FilterUI: Change filter
-    FilterUI->>FilterUI: Dispatch "reDisplayWalks" event
-    WalksTabs->>Events: setDisplayFilter(filter)
-    Events->>Events: forEach(event => setDisplayFilter)
+    FilterUI->>FilterUI: "Dispatch \"reDisplayWalks\" event"
+    WalksTabs->>Events: "setDisplayFilter(filter)"
+    Events->>Events: "forEach(event => setDisplayFilter)"
     Events->>WalksTabs: Trigger re-render
-    WalksTabs->>WalksTabs: displayWalks()
+    WalksTabs->>WalksTabs: "displayWalks()"
     WalksTabs->>User: Update visible items
 ```
 
@@ -295,13 +295,13 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP[RJsonwalksStdDisplay<br/>RJsonwalksLeafletMapmarker]
-    Loader[RLoad::addScript]
-    Leaflet[RLeafletScript::add]
-    BaseJS[/media/js<br/>ra.js, ra.tabs.js, ra.paginatedDataList.js, ra.walk.js]
-    StdJS[/media/jsonwalks/std/display.js]
-    MapJS[/media/jsonwalks/leaflet/mapmarker.js]
-    Bootstrap[ra.bootstrapper → ra.display.walksTabs / ra.display.walksMap]
+    PHP["RJsonwalksStdDisplay\nRJsonwalksLeafletMapmarker"]
+    Loader["RLoad::addScript"]
+    Leaflet["RLeafletScript::add"]
+    BaseJS["/media/js\nra.js, ra.tabs.js, ra.paginatedDataList.js, ra.walk.js"]
+    StdJS["/media/jsonwalks/std/display.js"]
+    MapJS["/media/jsonwalks/leaflet/mapmarker.js"]
+    Bootstrap["ra.bootstrapper → ra.display.walksTabs / ra.display.walksMap"]
 
     PHP --> Loader
     Loader --> BaseJS

--- a/media/jsonwalks/HLD.md
+++ b/media/jsonwalks/HLD.md
@@ -18,27 +18,27 @@ The `media/jsonwalks` module provides client-side JavaScript for rendering walk 
 ```mermaid
 flowchart TB
     subgraph Core["Core Integration"]
-        Bootstrap["ra.bootstrapper\nInitialization"]
-        Events["ra.events\nEvent collection"]
+        Bootstrap["ra.bootstrapper<br/>Initialization"]
+        Events["ra.events<br/>Event collection"]
     end
 
     subgraph StdDisplay["Standard Display (display.js)"]
-        WalksTabs["ra.display.walksTabs\nTabbed interface"]
-        GradesView["Grades View\nGrade-based display"]
-        ListView["List View\nList format"]
-        TableView["Table View\nTable format"]
-        CalendarView["Calendar View\nFullCalendar"]
-        MapView["Map View\nLeaflet map"]
+        WalksTabs["ra.display.walksTabs<br/>Tabbed interface"]
+        GradesView["Grades View<br/>Grade-based display"]
+        ListView["List View<br/>List format"]
+        TableView["Table View<br/>Table format"]
+        CalendarView["Calendar View<br/>FullCalendar"]
+        MapView["Map View<br/>Leaflet map"]
     end
 
     subgraph MapDisplay["Map Marker Display (mapmarker.js)"]
-        WalksMap["ra.display.walksMap\nMap markers"]
+        WalksMap["ra.display.walksMap<br/>Map markers"]
         Cluster[Marker clustering]
     end
 
     subgraph Specialized["Specialized Displays"]
-        MLScript["ml/script.js\nMonthly listing"]
-        SR02Display["sr02/display.js\nSR02 custom format"]
+        MLScript["ml/script.js<br/>Monthly listing"]
+        SR02Display["sr02/display.js<br/>SR02 custom format"]
     end
 
     Bootstrap --> WalksTabs
@@ -203,7 +203,7 @@ sequenceDiagram
     participant Tabs as "ra.tabs"
     participant User as User Browser
 
-    PHP->>Doc: "setCommand(\"ra.display.walksTabs\")"
+    PHP->>Doc: "setCommand(ra.display.walksTabs)"
     PHP->>Doc: "setDataObject(walks + config)"
     PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
@@ -229,7 +229,7 @@ sequenceDiagram
     participant Events as "ra.events"
 
     User->>Tabs: Click tab button
-    Tabs->>Tabs: "Dispatch \"displayTabContents\" event"
+    Tabs->>Tabs: "Dispatch displayTabContents event"
     WalksTabs->>WalksTabs: "displayWalks()"
     alt Tab == "List"
         WalksTabs->>Display: "displayWalksList(tag)"
@@ -254,7 +254,7 @@ sequenceDiagram
     participant WalksTabs as "ra.display.walksTabs"
 
     User->>FilterUI: Change filter
-    FilterUI->>FilterUI: "Dispatch \"reDisplayWalks\" event"
+    FilterUI->>FilterUI: "Dispatch reDisplayWalks event"
     WalksTabs->>Events: "setDisplayFilter(filter)"
     Events->>Events: "forEach(event => setDisplayFilter)"
     Events->>WalksTabs: Trigger re-render
@@ -295,10 +295,10 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP["RJsonwalksStdDisplay\nRJsonwalksLeafletMapmarker"]
+    PHP["RJsonwalksStdDisplay<br/>RJsonwalksLeafletMapmarker"]
     Loader["RLoad::addScript"]
     Leaflet["RLeafletScript::add"]
-    BaseJS["/media/js\nra.js, ra.tabs.js, ra.paginatedDataList.js, ra.walk.js"]
+    BaseJS["/media/js<br/>ra.js, ra.tabs.js, ra.paginatedDataList.js, ra.walk.js"]
     StdJS["/media/jsonwalks/std/display.js"]
     MapJS["/media/jsonwalks/leaflet/mapmarker.js"]
     Bootstrap["ra.bootstrapper → ra.display.walksTabs / ra.display.walksMap"]

--- a/media/leaflet/HLD.md
+++ b/media/leaflet/HLD.md
@@ -20,38 +20,38 @@ The `media/leaflet` module provides comprehensive Leaflet.js integration for int
 ```mermaid
 flowchart TB
     subgraph Core["Core Map System"]
-        LeafletMap["ra.leafletmap\nMap wrapper"]
-        LeafletMapInternal["ra._leafletmap\nInternal map"]
-        Settings["ra.map.Settings\nSettings panel"]
+        LeafletMap["ra.leafletmap<br/>Map wrapper"]
+        LeafletMapInternal["ra._leafletmap<br/>Internal map"]
+        Settings["ra.map.Settings<br/>Settings panel"]
     end
 
     subgraph Layers["Map Layers"]
-        BaseLayers["Base Layers\nOSM, OS, ESRI"]
-        VectorLayers["Vector Layers\nMapLibre GL"]
-        CRS["Coordinate Systems\nEPSG:27700, 3857"]
+        BaseLayers["Base Layers<br/>OSM, OS, ESRI"]
+        VectorLayers["Vector Layers<br/>MapLibre GL"]
+        CRS["Coordinate Systems<br/>EPSG:27700, 3857"]
     end
 
     subgraph Controls["Map Controls"]
-        Places["L.Control.Places\nPlace management"]
-        Search["L.Control.Search\nLocation search"]
-        Tools["L.Control.Tools\nMap tools"]
-        SmartRoute["L.Control.SmartRoute\nRouting"]
-        GpxUpload["L.Control.GpxUpload\nGPX upload"]
-        GpxDownload["L.Control.GpxDownload\nGPX download"]
-        Mouse["L.Control.Mouse\nMouse position"]
-        MyLocation["L.Control.MyLocation\nUser location"]
+        Places["L.Control.Places<br/>Place management"]
+        Search["L.Control.Search<br/>Location search"]
+        Tools["L.Control.Tools<br/>Map tools"]
+        SmartRoute["L.Control.SmartRoute<br/>Routing"]
+        GpxUpload["L.Control.GpxUpload<br/>GPX upload"]
+        GpxDownload["L.Control.GpxDownload<br/>GPX download"]
+        Mouse["L.Control.Mouse<br/>Mouse position"]
+        MyLocation["L.Control.MyLocation<br/>User location"]
     end
 
     subgraph Display["Display Functions"]
-        GpxSingle["ra.display.gpxSingle\nGPX route"]
-        TableList["ra.display.tableList\nTable data"]
-        MapCompare["ra.display.mapCompare\nMap comparison"]
-        PlotRoute["ra.display.plotRoute\nRoute plotting"]
+        GpxSingle["ra.display.gpxSingle<br/>GPX route"]
+        TableList["ra.display.tableList<br/>Table data"]
+        MapCompare["ra.display.mapCompare<br/>Map comparison"]
+        PlotRoute["ra.display.plotRoute<br/>Route plotting"]
     end
 
     subgraph Utilities["Utilities"]
-        Cluster["ra.map.cluster\nMarker clustering"]
-        Table["ramblerstable.js\nTable rendering"]
+        Cluster["ra.map.cluster<br/>Marker clustering"]
+        Table["ramblerstable.js<br/>Table rendering"]
     end
 
     LeafletMap --> LeafletMapInternal
@@ -284,7 +284,7 @@ sequenceDiagram
     participant LeafletJS as "Leaflet.js"
     participant User as User Browser
 
-    PHP->>Doc: "setCommand(\"ra.display.*\")"
+    PHP->>Doc: "setCommand(ra.display.*)"
     PHP->>Doc: "setDataObject(data)"
     PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
@@ -371,9 +371,9 @@ sequenceDiagram
 flowchart LR
     PHP["RLeafletScript::add"]
     Loader["RLoad::addScript"]
-    BaseJS["/media/js\nra.js, ra.map.js, ra.tabs.js"]
+    BaseJS["/media/js<br/>ra.js, ra.map.js, ra.tabs.js"]
     LeafletJS[Leaflet core + CSS]
-    ModuleJS["/media/leaflet\nra.leafletmap.js, ra.map.settings.js, L.Control.*"]
+    ModuleJS["/media/leaflet<br/>ra.leafletmap.js, ra.map.settings.js, L.Control.*"]
     Bootstrap["ra.bootstrapper → ra.display.*"]
 
     PHP --> Loader

--- a/media/leaflet/HLD.md
+++ b/media/leaflet/HLD.md
@@ -20,38 +20,38 @@ The `media/leaflet` module provides comprehensive Leaflet.js integration for int
 ```mermaid
 flowchart TB
     subgraph Core["Core Map System"]
-        LeafletMap[ra.leafletmap<br/>Map wrapper]
-        LeafletMapInternal[ra._leafletmap<br/>Internal map]
-        Settings[ra.map.Settings<br/>Settings panel]
+        LeafletMap["ra.leafletmap\nMap wrapper"]
+        LeafletMapInternal["ra._leafletmap\nInternal map"]
+        Settings["ra.map.Settings\nSettings panel"]
     end
 
     subgraph Layers["Map Layers"]
-        BaseLayers[Base Layers<br/>OSM, OS, ESRI]
-        VectorLayers[Vector Layers<br/>MapLibre GL]
-        CRS[Coordinate Systems<br/>EPSG:27700, 3857]
+        BaseLayers["Base Layers\nOSM, OS, ESRI"]
+        VectorLayers["Vector Layers\nMapLibre GL"]
+        CRS["Coordinate Systems\nEPSG:27700, 3857"]
     end
 
     subgraph Controls["Map Controls"]
-        Places[L.Control.Places<br/>Place management]
-        Search[L.Control.Search<br/>Location search]
-        Tools[L.Control.Tools<br/>Map tools]
-        SmartRoute[L.Control.SmartRoute<br/>Routing]
-        GpxUpload[L.Control.GpxUpload<br/>GPX upload]
-        GpxDownload[L.Control.GpxDownload<br/>GPX download]
-        Mouse[L.Control.Mouse<br/>Mouse position]
-        MyLocation[L.Control.MyLocation<br/>User location]
+        Places["L.Control.Places\nPlace management"]
+        Search["L.Control.Search\nLocation search"]
+        Tools["L.Control.Tools\nMap tools"]
+        SmartRoute["L.Control.SmartRoute\nRouting"]
+        GpxUpload["L.Control.GpxUpload\nGPX upload"]
+        GpxDownload["L.Control.GpxDownload\nGPX download"]
+        Mouse["L.Control.Mouse\nMouse position"]
+        MyLocation["L.Control.MyLocation\nUser location"]
     end
 
     subgraph Display["Display Functions"]
-        GpxSingle[ra.display.gpxSingle<br/>GPX route]
-        TableList[ra.display.tableList<br/>Table data]
-        MapCompare[ra.display.mapCompare<br/>Map comparison]
-        PlotRoute[ra.display.plotRoute<br/>Route plotting]
+        GpxSingle["ra.display.gpxSingle\nGPX route"]
+        TableList["ra.display.tableList\nTable data"]
+        MapCompare["ra.display.mapCompare\nMap comparison"]
+        PlotRoute["ra.display.plotRoute\nRoute plotting"]
     end
 
     subgraph Utilities["Utilities"]
-        Cluster[ra.map.cluster<br/>Marker clustering]
-        Table[ramblerstable.js<br/>Table rendering]
+        Cluster["ra.map.cluster\nMarker clustering"]
+        Table["ramblerstable.js\nTable rendering"]
     end
 
     LeafletMap --> LeafletMapInternal
@@ -278,22 +278,22 @@ sequenceDiagram
     autonumber
     participant PHP as RLeafletMap
     participant Doc as Joomla Document
-    participant Bootstrap as ra.bootstrapper
-    participant LeafletMap as ra.leafletmap
-    participant InternalMap as ra._leafletmap
-    participant LeafletJS as Leaflet.js
+    participant Bootstrap as "ra.bootstrapper"
+    participant LeafletMap as "ra.leafletmap"
+    participant InternalMap as "ra._leafletmap"
+    participant LeafletJS as "Leaflet.js"
     participant User as User Browser
 
-    PHP->>Doc: setCommand("ra.display.*")
-    PHP->>Doc: setDataObject(data)
-    PHP->>Doc: addScriptDeclaration(bootstrap)
+    PHP->>Doc: "setCommand(\"ra.display.*\")"
+    PHP->>Doc: "setDataObject(data)"
+    PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
-    User->>Bootstrap: ra.bootstrapper(jv, class, opts, data)
-    Bootstrap->>LeafletMap: new ra.leafletmap(tag, options)
-    LeafletMap->>InternalMap: new ra._leafletmap(tag, copyright, options)
-    InternalMap->>LeafletJS: new L.Map(div, options)
+    User->>Bootstrap: "ra.bootstrapper(jv, class, opts, data)"
+    Bootstrap->>LeafletMap: "new ra.leafletmap(tag, options)"
+    LeafletMap->>InternalMap: "new ra._leafletmap(tag, copyright, options)"
+    InternalMap->>LeafletJS: "new L.Map(div, options)"
     InternalMap->>InternalMap: Create base layers
-    InternalMap->>InternalMap: Setup vector layers (if keys)
+    InternalMap->>InternalMap: "Setup vector layers (if keys)"
     InternalMap->>InternalMap: Initialize controls
     LeafletMap->>User: Display map
 ```
@@ -302,15 +302,15 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant InternalMap as ra._leafletmap
+    participant InternalMap as "ra._leafletmap"
     participant Control as Map Control
     participant Map as Leaflet Map
 
     InternalMap->>InternalMap: Check control options
     alt Control enabled
-        InternalMap->>Control: new Control(options)
-        Control->>Control: onAdd(map)
-        Control->>Map: addControl(control)
+        InternalMap->>Control: "new Control(options)"
+        Control->>Control: "onAdd(map)"
+        Control->>Map: "addControl(control)"
         Control->>User: Render control UI
     end
 ```
@@ -319,21 +319,21 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant Bootstrap as ra.bootstrapper
-    participant GpxDisplay as ra.display.gpxSingle
-    participant GPXLib as L.GPX
+    participant Bootstrap as "ra.bootstrapper"
+    participant GpxDisplay as "ra.display.gpxSingle"
+    participant GPXLib as "L.GPX"
     participant Elevation as Elevation Control
     participant Map as Leaflet Map
 
-    Bootstrap->>GpxDisplay: new GpxDisplay(options, data)
-    GpxDisplay->>GpxDisplay: load()
-    GpxDisplay->>GPXLib: new L.GPX(file, options)
+    Bootstrap->>GpxDisplay: "new GpxDisplay(options, data)"
+    GpxDisplay->>GpxDisplay: "load()"
+    GpxDisplay->>GPXLib: "new L.GPX(file, options)"
     GPXLib->>GPXLib: Parse GPX file
-    GPXLib->>Map: addTo(map)
+    GPXLib->>Map: "addTo(map)"
     GPXLib->>GPXLib: Dispatch 'addline' event
-    GPXLib->>Elevation: addData(line)
+    GPXLib->>Elevation: "addData(line)"
     GPXLib->>GPXLib: Dispatch 'loaded' event
-    GpxDisplay->>GpxDisplay: displayGpxdetails()
+    GpxDisplay->>GpxDisplay: "displayGpxdetails()"
     GpxDisplay->>User: Show route and stats
 ```
 
@@ -369,12 +369,12 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP[RLeafletScript::add]
-    Loader[RLoad::addScript]
-    BaseJS[/media/js<br/>ra.js, ra.map.js, ra.tabs.js]
+    PHP["RLeafletScript::add"]
+    Loader["RLoad::addScript"]
+    BaseJS["/media/js\nra.js, ra.map.js, ra.tabs.js"]
     LeafletJS[Leaflet core + CSS]
-    ModuleJS[/media/leaflet<br/>ra.leafletmap.js, ra.map.settings.js, L.Control.*]
-    Bootstrap[ra.bootstrapper → ra.display.*]
+    ModuleJS["/media/leaflet\nra.leafletmap.js, ra.map.settings.js, L.Control.*"]
+    Bootstrap["ra.bootstrapper → ra.display.*"]
 
     PHP --> Loader
     Loader --> BaseJS

--- a/media/organisation/HLD.md
+++ b/media/organisation/HLD.md
@@ -17,15 +17,15 @@ The `media/organisation` module provides client-side JavaScript for displaying o
 ```mermaid
 flowchart TB
     subgraph Core["Core Integration"]
-        Bootstrap["ra.bootstrapper\nInitialization"]
-        LeafletMap["ra.leafletmap\nMap wrapper"]
-        Cluster["ra.map.cluster\nMarker clustering"]
+        Bootstrap["ra.bootstrapper<br/>Initialization"]
+        LeafletMap["ra.leafletmap<br/>Map wrapper"]
+        Cluster["ra.map.cluster<br/>Marker clustering"]
     end
 
     subgraph Display["Display Function"]
-        OrgMap["ra.display.organisationMap\nOrganisation display"]
-        Markers["Area/Group Markers\nMarker rendering"]
-        Popups["Popups\nInformation display"]
+        OrgMap["ra.display.organisationMap<br/>Organisation display"]
+        Markers["Area/Group Markers<br/>Marker rendering"]
+        Popups["Popups<br/>Information display"]
     end
 
     Bootstrap --> OrgMap
@@ -93,7 +93,7 @@ sequenceDiagram
     participant Cluster as "ra.map.cluster"
     participant User as User Browser
 
-    PHP->>Doc: "setCommand(\"ra.display.organisationMap\")"
+    PHP->>Doc: "setCommand(ra.display.organisationMap)"
     PHP->>Doc: "setDataObject(areas + groups + config)"
     PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
@@ -143,7 +143,7 @@ flowchart LR
     PHP["ROrganisation::display"]
     Loader["RLoad::addScript"]
     Map["RLeafletMap::display"]
-    BaseJS["/media/js\nra.js, ra.leafletmap.js, ra.tabs.js"]
+    BaseJS["/media/js<br/>ra.js, ra.leafletmap.js, ra.tabs.js"]
     OrgJS["/media/organisation/organisation.js"]
     Bootstrap["ra.bootstrapper → ra.display.organisationMap"]
 

--- a/media/organisation/HLD.md
+++ b/media/organisation/HLD.md
@@ -17,15 +17,15 @@ The `media/organisation` module provides client-side JavaScript for displaying o
 ```mermaid
 flowchart TB
     subgraph Core["Core Integration"]
-        Bootstrap[ra.bootstrapper<br/>Initialization]
-        LeafletMap[ra.leafletmap<br/>Map wrapper]
-        Cluster[ra.map.cluster<br/>Marker clustering]
+        Bootstrap["ra.bootstrapper\nInitialization"]
+        LeafletMap["ra.leafletmap\nMap wrapper"]
+        Cluster["ra.map.cluster\nMarker clustering"]
     end
 
     subgraph Display["Display Function"]
-        OrgMap[ra.display.organisationMap<br/>Organisation display]
-        Markers[Area/Group Markers<br/>Marker rendering]
-        Popups[Popups<br/>Information display]
+        OrgMap["ra.display.organisationMap\nOrganisation display"]
+        Markers["Area/Group Markers\nMarker rendering"]
+        Popups["Popups\nInformation display"]
     end
 
     Bootstrap --> OrgMap
@@ -87,30 +87,30 @@ sequenceDiagram
     autonumber
     participant PHP as ROrganisation
     participant Doc as Joomla Document
-    participant Bootstrap as ra.bootstrapper
-    participant OrgMap as ra.display.organisationMap
-    participant LeafletMap as ra.leafletmap
-    participant Cluster as ra.map.cluster
+    participant Bootstrap as "ra.bootstrapper"
+    participant OrgMap as "ra.display.organisationMap"
+    participant LeafletMap as "ra.leafletmap"
+    participant Cluster as "ra.map.cluster"
     participant User as User Browser
 
-    PHP->>Doc: setCommand("ra.display.organisationMap")
-    PHP->>Doc: setDataObject(areas + groups + config)
-    PHP->>Doc: addScriptDeclaration(bootstrap)
+    PHP->>Doc: "setCommand(\"ra.display.organisationMap\")"
+    PHP->>Doc: "setDataObject(areas + groups + config)"
+    PHP->>Doc: "addScriptDeclaration(bootstrap)"
     Doc->>User: Render page
-    User->>Bootstrap: ra.bootstrapper(jv, class, opts, data)
-    Bootstrap->>OrgMap: new OrgMap(options, data)
-    OrgMap->>OrgMap: load()
-    OrgMap->>LeafletMap: new ra.leafletmap(div, options)
-    OrgMap->>Cluster: new ra.map.cluster(map)
-    OrgMap->>OrgMap: addMarkers(areas)
+    User->>Bootstrap: "ra.bootstrapper(jv, class, opts, data)"
+    Bootstrap->>OrgMap: "new OrgMap(options, data)"
+    OrgMap->>OrgMap: "load()"
+    OrgMap->>LeafletMap: "new ra.leafletmap(div, options)"
+    OrgMap->>Cluster: "new ra.map.cluster(map)"
+    OrgMap->>OrgMap: "addMarkers(areas)"
     loop for each area
-        OrgMap->>OrgMap: addMarker(area)
+        OrgMap->>OrgMap: "addMarker(area)"
         loop for each group in area
-            OrgMap->>OrgMap: addMarker(group, area)
+            OrgMap->>OrgMap: "addMarker(group, area)"
         end
     end
-    OrgMap->>Cluster: addClusterMarkers()
-    OrgMap->>Cluster: zoomAll()
+    OrgMap->>Cluster: "addClusterMarkers()"
+    OrgMap->>Cluster: "zoomAll()"
     OrgMap->>User: Display map
 ```
 
@@ -140,12 +140,12 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP[ROrganisation::display]
-    Loader[RLoad::addScript]
-    Map[RLeafletMap::display]
-    BaseJS[/media/js<br/>ra.js, ra.leafletmap.js, ra.tabs.js]
-    OrgJS[/media/organisation/organisation.js]
-    Bootstrap[ra.bootstrapper → ra.display.organisationMap]
+    PHP["ROrganisation::display"]
+    Loader["RLoad::addScript"]
+    Map["RLeafletMap::display"]
+    BaseJS["/media/js\nra.js, ra.leafletmap.js, ra.tabs.js"]
+    OrgJS["/media/organisation/organisation.js"]
+    Bootstrap["ra.bootstrapper → ra.display.organisationMap"]
 
     PHP --> Loader
     Loader --> BaseJS

--- a/media/vendors/HLD.md
+++ b/media/vendors/HLD.md
@@ -17,25 +17,25 @@ The `media/vendors` module contains third-party vendor libraries that are either
 ```mermaid
 flowchart TB
     subgraph Pagination["Pagination"]
-        CvList[cvList.js<br/>List pagination]
-        CvListES6[cvList_ES6.js<br/>ES6 version]
+        CvList["cvList.js\nList pagination"]
+        CvListES6["cvList_ES6.js\nES6 version"]
     end
 
     subgraph GPX["GPX Processing"]
-        LeafletGpx[leaflet-gpx-1.3.1/gpx.js<br/>GPX parser]
-        Elevation[Leaflet.Elevation-0.0.4-ra<br/>Elevation profiles]
+        LeafletGpx["leaflet-gpx-1.3.1/gpx.js\nGPX parser"]
+        Elevation["Leaflet.Elevation-0.0.4-ra\nElevation profiles"]
     end
 
     subgraph Coordinates["Coordinate Systems"]
-        Geodesy[geodesy/<br/>Coordinate conversion]
-        OsGridRef[osgridref.js<br/>OS Grid Reference]
-        LatLon[latlon-ellipsoidal.js<br/>Lat/Lon calculations]
+        Geodesy["geodesy/\nCoordinate conversion"]
+        OsGridRef["osgridref.js\nOS Grid Reference"]
+        LatLon["latlon-ellipsoidal.js\nLat/Lon calculations"]
     end
 
     subgraph Integration["Integration Points"]
-        Display[Display Modules<br/>Use cvList]
-        GpxDisplay[GPX Display<br/>Use gpx.js + elevation]
-        MapControls[Map Controls<br/>Use geodesy]
+        Display["Display Modules\nUse cvList"]
+        GpxDisplay["GPX Display\nUse gpx.js + elevation"]
+        MapControls["Map Controls\nUse geodesy"]
     end
 
     CvList --> Display
@@ -186,15 +186,15 @@ sequenceDiagram
     participant Pagination as Pagination Control
     participant User as User
 
-    Display->>CvList: new cvList(container)
-    Display->>CvList: addItem(element) for each item
-    Display->>CvList: display()
-    CvList->>CvList: _calcKeys() (apply filters)
-    CvList->>Pagination: createPagination(options)
-    CvList->>Pagination: setPagination(keys)
+    Display->>CvList: "new cvList(container)"
+    Display->>CvList: "addItem(element) for each item"
+    Display->>CvList: "display()"
+    CvList->>CvList: "_calcKeys() (apply filters)"
+    CvList->>Pagination: "createPagination(options)"
+    CvList->>Pagination: "setPagination(keys)"
     CvList->>User: Render paginated items
-    User->>Pagination: Change page/items per page
-    Pagination->>CvList: Dispatch "cvList-redisplay"
+    User->>Pagination: "Change page/items per page"
+    Pagination->>CvList: "Dispatch \"cvList-redisplay\""
     CvList->>User: Update display
 ```
 
@@ -202,20 +202,20 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
-    participant GpxDisplay as ra.display.gpxSingle
-    participant GpxLib as L.GPX
-    participant Elevation as L.Control.Elevation
+    participant GpxDisplay as "ra.display.gpxSingle"
+    participant GpxLib as "L.GPX"
+    participant Elevation as "L.Control.Elevation"
     participant Map as Leaflet Map
 
-    GpxDisplay->>GpxLib: new L.GPX(file, options)
-    GpxLib->>GpxLib: Parse GPX file (async)
+    GpxDisplay->>GpxLib: "new L.GPX(file, options)"
+    GpxLib->>GpxLib: "Parse GPX file (async)"
     GpxLib->>GpxLib: Dispatch 'addline' event
-    GpxLib->>Elevation: addData(line)
+    GpxLib->>Elevation: "addData(line)"
     Elevation->>Elevation: Calculate elevation data
     Elevation->>Elevation: Render D3 chart
-    GpxLib->>Map: addTo(map)
+    GpxLib->>Map: "addTo(map)"
     GpxLib->>GpxLib: Dispatch 'loaded' event
-    GpxDisplay->>GpxDisplay: displayGpxdetails()
+    GpxDisplay->>GpxDisplay: "displayGpxdetails()"
 ```
 
 ## Integration Points
@@ -248,11 +248,11 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP[RJsonwalksStdDisplay<br/>RWalkseditorProgramme<br/>RLeafletScript]
-    Loader[RLoad::addScript]
-    Vendors[/media/vendors<br/>cvList, Leaflet.Elevation, leaflet-gpx, geodesy]
-    BaseJS[/media/js foundation]
-    Bootstrap[ra.bootstrapper + map bootstraps]
+    PHP["RJsonwalksStdDisplay\nRWalkseditorProgramme\nRLeafletScript"]
+    Loader["RLoad::addScript"]
+    Vendors["/media/vendors\ncvList, Leaflet.Elevation, leaflet-gpx, geodesy"]
+    BaseJS["/media/js foundation"]
+    Bootstrap["ra.bootstrapper + map bootstraps"]
 
     PHP --> Loader
     Loader --> Vendors

--- a/media/vendors/HLD.md
+++ b/media/vendors/HLD.md
@@ -17,25 +17,25 @@ The `media/vendors` module contains third-party vendor libraries that are either
 ```mermaid
 flowchart TB
     subgraph Pagination["Pagination"]
-        CvList["cvList.js\nList pagination"]
-        CvListES6["cvList_ES6.js\nES6 version"]
+        CvList["cvList.js<br/>List pagination"]
+        CvListES6["cvList_ES6.js<br/>ES6 version"]
     end
 
     subgraph GPX["GPX Processing"]
-        LeafletGpx["leaflet-gpx-1.3.1/gpx.js\nGPX parser"]
-        Elevation["Leaflet.Elevation-0.0.4-ra\nElevation profiles"]
+        LeafletGpx["leaflet-gpx-1.3.1/gpx.js<br/>GPX parser"]
+        Elevation["Leaflet.Elevation-0.0.4-ra<br/>Elevation profiles"]
     end
 
     subgraph Coordinates["Coordinate Systems"]
-        Geodesy["geodesy/\nCoordinate conversion"]
-        OsGridRef["osgridref.js\nOS Grid Reference"]
-        LatLon["latlon-ellipsoidal.js\nLat/Lon calculations"]
+        Geodesy["geodesy/<br/>Coordinate conversion"]
+        OsGridRef["osgridref.js<br/>OS Grid Reference"]
+        LatLon["latlon-ellipsoidal.js<br/>Lat/Lon calculations"]
     end
 
     subgraph Integration["Integration Points"]
-        Display["Display Modules\nUse cvList"]
-        GpxDisplay["GPX Display\nUse gpx.js + elevation"]
-        MapControls["Map Controls\nUse geodesy"]
+        Display["Display Modules<br/>Use cvList"]
+        GpxDisplay["GPX Display<br/>Use gpx.js + elevation"]
+        MapControls["Map Controls<br/>Use geodesy"]
     end
 
     CvList --> Display
@@ -194,7 +194,7 @@ sequenceDiagram
     CvList->>Pagination: "setPagination(keys)"
     CvList->>User: Render paginated items
     User->>Pagination: "Change page/items per page"
-    Pagination->>CvList: "Dispatch \"cvList-redisplay\""
+    Pagination->>CvList: "Dispatch cvList-redisplay"
     CvList->>User: Update display
 ```
 
@@ -248,9 +248,9 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP["RJsonwalksStdDisplay\nRWalkseditorProgramme\nRLeafletScript"]
+    PHP["RJsonwalksStdDisplay<br/>RWalkseditorProgramme<br/>RLeafletScript"]
     Loader["RLoad::addScript"]
-    Vendors["/media/vendors\ncvList, Leaflet.Elevation, leaflet-gpx, geodesy"]
+    Vendors["/media/vendors<br/>cvList, Leaflet.Elevation, leaflet-gpx, geodesy"]
     BaseJS["/media/js foundation"]
     Bootstrap["ra.bootstrapper + map bootstraps"]
 

--- a/media/walkseditor/HLD.md
+++ b/media/walkseditor/HLD.md
@@ -19,25 +19,25 @@ The `media/walkseditor` module provides a complete walk editing interface with b
 ```mermaid
 flowchart TB
     subgraph Frontend["JavaScript Frontend"]
-        WalkEditor[ra.walkseditor.walkeditor<br/>Main editor]
-        InputFields[ra.walkseditor.inputFields<br/>Form fields]
-        PlaceEditor[ra.walkseditor.placeEditor<br/>Place editing]
-        MapLocation[ra.walkseditor.maplocation<br/>Map integration]
-        ViewWalks[ra.walkseditor.viewWalks<br/>Walk viewing]
-        FormSubmit[form/submitwalk.js<br/>Form submission]
-        Programme[form/programme.js<br/>Programme management]
+        WalkEditor["ra.walkseditor.walkeditor\nMain editor"]
+        InputFields["ra.walkseditor.inputFields\nForm fields"]
+        PlaceEditor["ra.walkseditor.placeEditor\nPlace editing"]
+        MapLocation["ra.walkseditor.maplocation\nMap integration"]
+        ViewWalks["ra.walkseditor.viewWalks\nWalk viewing"]
+        FormSubmit["form/submitwalk.js\nForm submission"]
+        Programme["form/programme.js\nProgramme management"]
     end
 
     subgraph Backend["PHP Backend"]
-        SendEmail[sendemail.php<br/>Email handler]
-        PHPMailer[PHPMailer.php<br/>Email library]
-        SMTP[SMTP.php<br/>SMTP transport]
-        Exception[Exception.php<br/>Error handling]
+        SendEmail["sendemail.php\nEmail handler"]
+        PHPMailer["PHPMailer.php\nEmail library"]
+        SMTP["SMTP.php\nSMTP transport"]
+        Exception["Exception.php\nError handling"]
     end
 
     subgraph Integration["Integration"]
-        JoomlaConfig[Joomla Configuration<br/>Email settings]
-        LeafletMap[Leaflet Map<br/>Location selection]
+        JoomlaConfig["Joomla Configuration\nEmail settings"]
+        LeafletMap["Leaflet Map\nLocation selection"]
     end
 
     WalkEditor --> InputFields
@@ -199,32 +199,32 @@ sequenceDiagram
     participant Editor as Walk Editor JS
     participant Validate as Form Validation
     participant AJAX as AJAX Request
-    participant SendEmail as sendemail.php
+    participant SendEmail as "sendemail.php"
     participant PHPMailer as PHPMailer
     participant SMTP as SMTP Server
     participant Coordinator as Coordinator Email
 
     User->>Editor: Fill walk form
     User->>Editor: Click submit
-    Editor->>Validate: validateForm()
-    Validate-->>Editor: valid/invalid
+    Editor->>Validate: "validateForm()"
+    Validate-->>Editor: "valid/invalid"
     alt Valid
-        Editor->>AJAX: POST walk data (JSON)
+        Editor->>AJAX: "POST walk data (JSON)"
         AJAX->>SendEmail: Receive POST
-        SendEmail->>SendEmail: json_decode(data)
-        SendEmail->>SendEmail: checkDecode()
-        SendEmail->>PHPMailer: new PHPMailer()
-        SendEmail->>PHPMailer: Configure (SMTP/mail)
-        SendEmail->>PHPMailer: setFrom(), addAddress()
-        SendEmail->>PHPMailer: AddStringAttachment(walk JSON)
-        SendEmail->>PHPMailer: msgHTML(body)
+        SendEmail->>SendEmail: "json_decode(data)"
+        SendEmail->>SendEmail: "checkDecode()"
+        SendEmail->>PHPMailer: "new PHPMailer()"
+        SendEmail->>PHPMailer: "Configure (SMTP/mail)"
+        SendEmail->>PHPMailer: "setFrom(), addAddress()"
+        SendEmail->>PHPMailer: "AddStringAttachment(walk JSON)"
+        SendEmail->>PHPMailer: "msgHTML(body)"
         PHPMailer->>SMTP: Send email
         SMTP->>Coordinator: Deliver email
-        PHPMailer-->>SendEmail: Success/failure
+        PHPMailer-->>SendEmail: "Success/failure"
         SendEmail->>SendEmail: Create response object
         SendEmail-->>AJAX: JSON response
-        AJAX->>Editor: handleResponse()
-        Editor->>User: Show success/error message
+        AJAX->>Editor: "handleResponse()"
+        Editor->>User: "Show success/error message"
     else Invalid
         Editor->>User: Show validation errors
     end
@@ -244,7 +244,7 @@ sequenceDiagram
     User->>Map: Select location
     Map-->>PlaceEditor: Coordinates
     PlaceEditor->>PlaceEditor: Save place data
-    PlaceEditor->>Storage: Store place (localStorage/API)
+    PlaceEditor->>Storage: "Store place (localStorage/API)"
 ```
 
 ## Integration Points
@@ -274,12 +274,12 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    PHP[RWalkseditorProgramme / Submitform]
-    Loader[RLoad::addScript]
-    BaseJS[/media/js<br/>ra.tabs.js]
-    Vendors[/media/vendors/cvList/cvList.js]
-    EditorJS[/media/walkseditor/js<br/>walkeditor.js, walk.js, form/*.js]
-    Bootstrap[Bootstrap script → ra.walkseditor.walkeditor]
+    PHP["RWalkseditorProgramme / Submitform"]
+    Loader["RLoad::addScript"]
+    BaseJS["/media/js\nra.tabs.js"]
+    Vendors["/media/vendors/cvList/cvList.js"]
+    EditorJS["/media/walkseditor/js\nwalkeditor.js, walk.js, form/*.js"]
+    Bootstrap["Bootstrap script → ra.walkseditor.walkeditor"]
 
     PHP --> Loader
     Loader --> BaseJS

--- a/media/walkseditor/HLD.md
+++ b/media/walkseditor/HLD.md
@@ -19,25 +19,25 @@ The `media/walkseditor` module provides a complete walk editing interface with b
 ```mermaid
 flowchart TB
     subgraph Frontend["JavaScript Frontend"]
-        WalkEditor["ra.walkseditor.walkeditor\nMain editor"]
-        InputFields["ra.walkseditor.inputFields\nForm fields"]
-        PlaceEditor["ra.walkseditor.placeEditor\nPlace editing"]
-        MapLocation["ra.walkseditor.maplocation\nMap integration"]
-        ViewWalks["ra.walkseditor.viewWalks\nWalk viewing"]
-        FormSubmit["form/submitwalk.js\nForm submission"]
-        Programme["form/programme.js\nProgramme management"]
+        WalkEditor["ra.walkseditor.walkeditor<br/>Main editor"]
+        InputFields["ra.walkseditor.inputFields<br/>Form fields"]
+        PlaceEditor["ra.walkseditor.placeEditor<br/>Place editing"]
+        MapLocation["ra.walkseditor.maplocation<br/>Map integration"]
+        ViewWalks["ra.walkseditor.viewWalks<br/>Walk viewing"]
+        FormSubmit["form/submitwalk.js<br/>Form submission"]
+        Programme["form/programme.js<br/>Programme management"]
     end
 
     subgraph Backend["PHP Backend"]
-        SendEmail["sendemail.php\nEmail handler"]
-        PHPMailer["PHPMailer.php\nEmail library"]
-        SMTP["SMTP.php\nSMTP transport"]
-        Exception["Exception.php\nError handling"]
+        SendEmail["sendemail.php<br/>Email handler"]
+        PHPMailer["PHPMailer.php<br/>Email library"]
+        SMTP["SMTP.php<br/>SMTP transport"]
+        Exception["Exception.php<br/>Error handling"]
     end
 
     subgraph Integration["Integration"]
-        JoomlaConfig["Joomla Configuration\nEmail settings"]
-        LeafletMap["Leaflet Map\nLocation selection"]
+        JoomlaConfig["Joomla Configuration<br/>Email settings"]
+        LeafletMap["Leaflet Map<br/>Location selection"]
     end
 
     WalkEditor --> InputFields
@@ -276,9 +276,9 @@ sequenceDiagram
 flowchart LR
     PHP["RWalkseditorProgramme / Submitform"]
     Loader["RLoad::addScript"]
-    BaseJS["/media/js\nra.tabs.js"]
+    BaseJS["/media/js<br/>ra.tabs.js"]
     Vendors["/media/vendors/cvList/cvList.js"]
-    EditorJS["/media/walkseditor/js\nwalkeditor.js, walk.js, form/*.js"]
+    EditorJS["/media/walkseditor/js<br/>walkeditor.js, walk.js, form/*.js"]
     Bootstrap["Bootstrap script → ra.walkseditor.walkeditor"]
 
     PHP --> Loader

--- a/organisation/HLD.md
+++ b/organisation/HLD.md
@@ -18,23 +18,23 @@ The `organisation` module manages Ramblers organisation data (areas and groups) 
 ```mermaid
 flowchart TB
     subgraph Organisation["Organisation Module"]
-        ROrganisation["ROrganisation\nMain class"]
-        Area["ROrganisationArea\nArea object"]
-        Group["ROrganisationGroup\nGroup object"]
+        ROrganisation["ROrganisation<br/>Main class"]
+        Area["ROrganisationArea<br/>Area object"]
+        Group["ROrganisationGroup<br/>Group object"]
     end
 
     subgraph Data["Data Sources"]
-        FeedHelper["RFeedhelper\nHTTP feed"]
-        OrgFeed["Organisation JSON Feed\ngroups.theramblers.org.uk"]
+        FeedHelper["RFeedhelper<br/>HTTP feed"]
+        OrgFeed["Organisation JSON Feed<br/>groups.theramblers.org.uk"]
     end
 
     subgraph Display["Display Layer"]
-        LeafletMap["RLeafletMap\nMap rendering"]
-        Html["RHtml\nHTML formatting"]
+        LeafletMap["RLeafletMap<br/>Map rendering"]
+        Html["RHtml<br/>HTML formatting"]
     end
 
     subgraph Client["Client-Side"]
-        OrgJS["organisation.js\nMap display"]
+        OrgJS["organisation.js<br/>Map display"]
     end
 
     ROrganisation --> FeedHelper
@@ -174,7 +174,7 @@ flowchart LR
     Org["ROrganisation::display"]
     Loader["RLoad::addScript"]
     Map["RLeafletMap::display"]
-    BaseJS["/media/js\nra.js, ra.map.js, ra.tabs.js"]
+    BaseJS["/media/js<br/>ra.js, ra.map.js, ra.tabs.js"]
     OrgJS["/media/organisation/organisation.js"]
     Bootstrap["ra.bootstrapper → ra.display.organisationMap"]
 

--- a/organisation/HLD.md
+++ b/organisation/HLD.md
@@ -18,23 +18,23 @@ The `organisation` module manages Ramblers organisation data (areas and groups) 
 ```mermaid
 flowchart TB
     subgraph Organisation["Organisation Module"]
-        ROrganisation[ROrganisation<br/>Main class]
-        Area[ROrganisationArea<br/>Area object]
-        Group[ROrganisationGroup<br/>Group object]
+        ROrganisation["ROrganisation\nMain class"]
+        Area["ROrganisationArea\nArea object"]
+        Group["ROrganisationGroup\nGroup object"]
     end
 
     subgraph Data["Data Sources"]
-        FeedHelper[RFeedhelper<br/>HTTP feed]
-        OrgFeed[Organisation JSON Feed<br/>groups.theramblers.org.uk]
+        FeedHelper["RFeedhelper\nHTTP feed"]
+        OrgFeed["Organisation JSON Feed\ngroups.theramblers.org.uk"]
     end
 
     subgraph Display["Display Layer"]
-        LeafletMap[RLeafletMap<br/>Map rendering]
-        Html[RHtml<br/>HTML formatting]
+        LeafletMap["RLeafletMap\nMap rendering"]
+        Html["RHtml\nHTML formatting"]
     end
 
     subgraph Client["Client-Side"]
-        OrgJS[organisation.js<br/>Map display]
+        OrgJS["organisation.js\nMap display"]
     end
 
     ROrganisation --> FeedHelper
@@ -114,22 +114,22 @@ public $mapZoom = -1;
 ```mermaid
 sequenceDiagram
     autonumber
-    participant Caller as Module/Page
+    participant Caller as "Module/Page"
     participant ROrganisation as ROrganisation
     participant FeedHelper as RFeedhelper
     participant OrgFeed as Organisation Feed
     participant Areas as Areas Array
     participant Groups as Groups Array
 
-    Caller->>ROrganisation: new()
-    ROrganisation->>ROrganisation: load()
-    ROrganisation->>FeedHelper: new(cache, 60)
-    ROrganisation->>FeedHelper: getFeed(url, title)
+    Caller->>ROrganisation: "new()"
+    ROrganisation->>ROrganisation: "load()"
+    ROrganisation->>FeedHelper: "new(cache, 60)"
+    ROrganisation->>FeedHelper: "getFeed(url, title)"
     FeedHelper->>OrgFeed: HTTP request
     OrgFeed-->>FeedHelper: JSON response
     FeedHelper-->>ROrganisation: contents
-    ROrganisation->>ROrganisation: json_decode()
-    ROrganisation->>ROrganisation: convert(json)
+    ROrganisation->>ROrganisation: "json_decode()"
+    ROrganisation->>ROrganisation: "convert(json)"
     ROrganisation->>Areas: Populate areas[]
     ROrganisation->>Groups: Populate groups[]
 ```
@@ -171,12 +171,12 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    Org[ROrganisation::display]
-    Loader[RLoad::addScript]
-    Map[RLeafletMap::display]
-    BaseJS[/media/js<br/>ra.js, ra.map.js, ra.tabs.js]
-    OrgJS[/media/organisation/organisation.js]
-    Bootstrap[ra.bootstrapper → ra.display.organisationMap]
+    Org["ROrganisation::display"]
+    Loader["RLoad::addScript"]
+    Map["RLeafletMap::display"]
+    BaseJS["/media/js\nra.js, ra.map.js, ra.tabs.js"]
+    OrgJS["/media/organisation/organisation.js"]
+    Bootstrap["ra.bootstrapper → ra.display.organisationMap"]
 
     Org --> Loader
     Loader --> BaseJS

--- a/sql/HLD.md
+++ b/sql/HLD.md
@@ -16,17 +16,17 @@ The `sql` module provides database utility functions for Joomla database operati
 ```mermaid
 flowchart TB
     subgraph Sql["SQL Module"]
-        SqlUtils[RSqlUtils<br/>Static utility class]
+        SqlUtils["RSqlUtils\nStatic utility class"]
     end
 
     subgraph Functions["Functions"]
-        TableExists[tableExists<br/>Check table]
+        TableExists["tableExists\nCheck table"]
     end
 
     subgraph Integration["Integration"]
-        Accounts[RAccounts<br/>Table validation]
-        Organisation[ROrganisation<br/>Table checks]
-        JoomlaDB[Joomla Database<br/>getDbo()]
+        Accounts["RAccounts\nTable validation"]
+        Organisation["ROrganisation\nTable checks"]
+        JoomlaDB["Joomla Database\ngetDbo()"]
     end
 
     SqlUtils --> TableExists
@@ -64,13 +64,13 @@ sequenceDiagram
     participant JoomlaDB as Joomla Database
     participant Tables as Table List
 
-    Caller->>SqlUtils: tableExists('table_name')
-    SqlUtils->>JoomlaDB: getDbo()
-    SqlUtils->>JoomlaDB: replacePrefix('#__table')
-    SqlUtils->>JoomlaDB: getTableList()
+    Caller->>SqlUtils: "tableExists('table_name')"
+    SqlUtils->>JoomlaDB: "getDbo()"
+    SqlUtils->>JoomlaDB: "replacePrefix('#__table')"
+    SqlUtils->>JoomlaDB: "getTableList()"
     JoomlaDB-->>SqlUtils: tables[]
     SqlUtils->>SqlUtils: Check if table in list
-    SqlUtils-->>Caller: true/false
+    SqlUtils-->>Caller: "true/false"
 ```
 
 ## Integration Points

--- a/sql/HLD.md
+++ b/sql/HLD.md
@@ -16,17 +16,17 @@ The `sql` module provides database utility functions for Joomla database operati
 ```mermaid
 flowchart TB
     subgraph Sql["SQL Module"]
-        SqlUtils["RSqlUtils\nStatic utility class"]
+        SqlUtils["RSqlUtils<br/>Static utility class"]
     end
 
     subgraph Functions["Functions"]
-        TableExists["tableExists\nCheck table"]
+        TableExists["tableExists<br/>Check table"]
     end
 
     subgraph Integration["Integration"]
-        Accounts["RAccounts\nTable validation"]
-        Organisation["ROrganisation\nTable checks"]
-        JoomlaDB["Joomla Database\ngetDbo()"]
+        Accounts["RAccounts<br/>Table validation"]
+        Organisation["ROrganisation<br/>Table checks"]
+        JoomlaDB["Joomla Database<br/>getDbo()"]
     end
 
     SqlUtils --> TableExists

--- a/walkseditor/HLD.md
+++ b/walkseditor/HLD.md
@@ -16,20 +16,20 @@ The `walkseditor` module provides the walk editing interface for creating and ma
 ```mermaid
 flowchart TB
     subgraph Server["Server Components"]
-        Loader["RWalkseditor\nAsset loader"]
-        Programme["RWalkseditorProgramme\nprogramme.php"]
-        Submit["RWalkseditorSubmitform\nsubmitform.php"]
+        Loader["RWalkseditor<br/>Asset loader"]
+        Programme["RWalkseditorProgramme<br/>programme.php"]
+        Submit["RWalkseditorSubmitform<br/>submitform.php"]
     end
 
     subgraph Client["Client Assets"]
-        EditorJS["walkeditor.js\nwalksEditorHelps.js\nviewWalks.js"]
-        FormJS["walk.js\ninputfields.js\nloader.js\nmaplocation.js\nplaceEditor.js"]
+        EditorJS["walkeditor.js<br/>walksEditorHelps.js<br/>viewWalks.js"]
+        FormJS["walk.js<br/>inputfields.js<br/>loader.js<br/>maplocation.js<br/>placeEditor.js"]
         ProgrammeJS["form/programme.js"]
         SubmitJS["form/submitwalk.js"]
-        CompJS["comp/viewAllWalks.js\ncomp/viewAllPlaces.js"]
-        Foundation["ra.tabs.js\ncvList.js"]
+        CompJS["comp/viewAllWalks.js<br/>comp/viewAllPlaces.js"]
+        Foundation["ra.tabs.js<br/>cvList.js"]
         Quill["Quill JS/CSS (CDN)"]
-        Styles["style.css\nra.tabs.css"]
+        Styles["style.css<br/>ra.tabs.css"]
     end
 
     Programme --> Loader

--- a/walkseditor/HLD.md
+++ b/walkseditor/HLD.md
@@ -16,20 +16,20 @@ The `walkseditor` module provides the walk editing interface for creating and ma
 ```mermaid
 flowchart TB
     subgraph Server["Server Components"]
-        Loader[RWalkseditor<br/>Asset loader]
-        Programme[RWalkseditorProgramme<br/>programme.php]
-        Submit[RWalkseditorSubmitform<br/>submitform.php]
+        Loader["RWalkseditor\nAsset loader"]
+        Programme["RWalkseditorProgramme\nprogramme.php"]
+        Submit["RWalkseditorSubmitform\nsubmitform.php"]
     end
 
     subgraph Client["Client Assets"]
-        EditorJS[walkeditor.js<br/>walksEditorHelps.js<br/>viewWalks.js]
-        FormJS[walk.js<br/>inputfields.js<br/>loader.js<br/>maplocation.js<br/>placeEditor.js]
-        ProgrammeJS[form/programme.js]
-        SubmitJS[form/submitwalk.js]
-        CompJS[comp/viewAllWalks.js<br/>comp/viewAllPlaces.js]
-        Foundation[ra.tabs.js<br/>cvList.js]
-        Quill[Quill JS/CSS (CDN)]
-        Styles[style.css<br/>ra.tabs.css]
+        EditorJS["walkeditor.js\nwalksEditorHelps.js\nviewWalks.js"]
+        FormJS["walk.js\ninputfields.js\nloader.js\nmaplocation.js\nplaceEditor.js"]
+        ProgrammeJS["form/programme.js"]
+        SubmitJS["form/submitwalk.js"]
+        CompJS["comp/viewAllWalks.js\ncomp/viewAllPlaces.js"]
+        Foundation["ra.tabs.js\ncvList.js"]
+        Quill["Quill JS/CSS (CDN)"]
+        Styles["style.css\nra.tabs.css"]
     end
 
     Programme --> Loader
@@ -68,24 +68,24 @@ public function display()
 
 ```mermaid
 sequenceDiagram
-    participant Joomla as Joomla Page/Module
+    participant Joomla as "Joomla Page/Module"
     participant Programme as RWalkseditorProgramme
     participant Submit as RWalkseditorSubmitform
     participant Loader as RWalkseditor
     participant RLoad as RLoad
     participant Browser as Browser
-    participant ClientJS as walkeditor.js/form scripts
+    participant ClientJS as "walkeditor.js/form scripts"
 
-    Joomla->>Programme: display()
-    Programme->>Loader: addScriptsandCss()
-    Loader->>RLoad: addScript/addStyle for foundation + editor bundles
+    Joomla->>Programme: "display()"
+    Programme->>Loader: "addScriptsandCss()"
+    Loader->>RLoad: "addScript/addStyle for foundation + editor bundles"
     RLoad-->>Browser: inject assets
-    Browser->>ClientJS: initialize tabs, forms, lists
+    Browser->>ClientJS: "initialize tabs, forms, lists"
 
-    Joomla->>Submit: display()
-    Submit->>Loader: addScriptsandCss()
+    Joomla->>Submit: "display()"
+    Submit->>Loader: "addScriptsandCss()"
     Loader->>RLoad: enqueue submit form assets + Quill
-    Browser->>ClientJS: bind validation, map/location pickers
+    Browser->>ClientJS: "bind validation, map/location pickers"
 ```
 
 ## Integration Points


### PR DESCRIPTION
## Summary
- normalize Mermaid diagrams across architecture and module HLD docs for GitHub rendering, quoting punctuation-heavy labels and replacing HTML breaks with newline escapes
- standardize subgraph declarations and file-path nodes to rectangle shapes while preserving existing flows and relationships

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695479fd9e308321bf762fdc56aae0d1)